### PR TITLE
fix errors in cross/switch tables

### DIFF
--- a/luto/tools/__init__.py
+++ b/luto/tools/__init__.py
@@ -543,9 +543,9 @@ def map_desc_to_dvar_index(category:str,
                            dvar_arr:np.ndarray):
     '''Input:
         category: str, the category of the dvar, e.g., 'Agriculture/Non-Agriculture',
-        desc2idx: dict, the mapping between lu_desc and dvar index, e.g., {'dry':0,'irri':1},
+        desc2idx: dict, the mapping between lu_desc and dvar index, e.g., {'Apples': 0 ...},
         dvar_arr: np.ndarray, the dvar array with shape (r,{j|k}), where r is the number of pixels,
-                  and {j|k} is the number of landuses or commodities.
+                  and {j|k} is the dimension of ag-landuses or non-ag-landuses.
                   
     Return:
         pd.DataFrame, with columns of ['Category','lu_desc','dvar_idx','dvar'].'''

--- a/luto/tools/compmap.py
+++ b/luto/tools/compmap.py
@@ -53,10 +53,10 @@ def lumap_crossmap(oldmap, newmap, ag_landuses, non_ag_landuses, real_area):
     switches = crosstab.iloc[-1, 0:-1] - crosstab.iloc[0:-1, -1]
     nswitches = np.abs(switches).sum()
     switches['Total'] = nswitches
-    switches['Total [%]'] = int(np.around(100 * nswitches / oldmap.shape[0]))
+    switches['Total [%]'] = np.around(100 * nswitches / (real_area.sum()/100), decimals=2)
+    switches = pd.DataFrame(switches)
 
     return crosstab, switches
-
 
 def lmmap_crossmap(oldmap, newmap, real_area):
     # Produce the cross-tabulation matrix with optional labels.
@@ -67,35 +67,38 @@ def lmmap_crossmap(oldmap, newmap, real_area):
                            margins = True)
     
     crosstab = crosstab.reindex(crosstab.index, axis=1, fill_value=0)
+    crosstab.columns = crosstab.columns.tolist()
+    crosstab.index = crosstab.index.tolist()
 
     # Calculate net switches to land use (negative means switch away).
     switches = crosstab.iloc[-1, 0:-1] - crosstab.iloc[0:-1, -1]
     nswitches = np.abs(switches).sum()
     switches['Total'] = nswitches
-    switches['Total [%]'] = int(np.around(100 * nswitches / oldmap.shape[0]))
+    switches['Total [%]'] = np.around(100 * nswitches / (real_area.sum()/100),decimals=2)
+    switches = pd.DataFrame(switches)
 
     return crosstab, switches
 
 
-def ammap_crossmap(oldmap, newmap, am):
-    # Produce the cross-tabulation matrix with optional labels for a single ammap.
-    crosstab = pd.crosstab(oldmap, newmap, margins = True)
+# def ammap_crossmap(oldmap, newmap, am):
+#     # Produce the cross-tabulation matrix with optional labels for a single ammap.
+#     crosstab = pd.crosstab(oldmap, newmap, margins = True)
 
-    reindex =  [0, 1, 'All']
-    crosstab = crosstab.reindex(reindex, axis = 0, fill_value = 0)
-    crosstab = crosstab.reindex(reindex, axis = 1, fill_value = 0)
+#     reindex =  [0, 1, 'All']
+#     crosstab = crosstab.reindex(reindex, axis = 0, fill_value = 0)
+#     crosstab = crosstab.reindex(reindex, axis = 1, fill_value = 0)
 
-    ind_names = ['(None)', am, 'Total']
-    crosstab.columns = ind_names
-    crosstab.index = ind_names
+#     ind_names = ['(None)', am, 'Total']
+#     crosstab.columns = ind_names
+#     crosstab.index = ind_names
 
-    # Calculate net switches to land use (negative means switch away).
-    switches = crosstab.iloc[-1, 0:-1] - crosstab.iloc[0:-1, -1]
-    nswitches = np.abs(switches).sum()
-    switches['Total'] = nswitches
-    switches['Total [%]'] = int(np.around(100 * nswitches / oldmap.shape[0]))
+#     # Calculate net switches to land use (negative means switch away).
+#     switches = crosstab.iloc[-1, 0:-1] - crosstab.iloc[0:-1, -1]
+#     nswitches = np.abs(switches).sum()
+#     switches['Total'] = nswitches
+#     switches['Total [%]'] = int(np.around(100 * nswitches / oldmap.shape[0]))
 
-    return crosstab, switches
+#     return crosstab, switches
 
 
 
@@ -147,10 +150,9 @@ def crossmap_irrstat( lumap_old
     df['Area prior [ km2 ]'] = cells_prior
     df['Area after [ km2 ]'] = cells_after
     df.fillna(0, inplace=True)
-    df = df.astype(np.int64)
     switches = df['Area after [ km2 ]']-  df['Area prior [ km2 ]']
     nswitches = np.abs(switches).sum()
-    pswitches = int(np.around(100 * nswitches / lumap_old.shape[0]))
+    pswitches = np.around(100 * nswitches / (real_area.sum()/100), decimals=2)
 
     df['Switches [ km2 ]'] = switches
     df['Switches [ % ]'] = 100 * switches / cells_prior
@@ -212,10 +214,9 @@ def crossmap_amstat( am
     df['Area prior [ km2 ]'] = cells_prior
     df['Area after [ km2 ]'] = cells_after
     df.fillna(0, inplace=True)
-    df = df.astype(np.int64)
     switches = df['Area after [ km2 ]']-  df['Area prior [ km2 ]']
     nswitches = np.abs(switches).sum()
-    pswitches = int(np.around(100 * nswitches / lumap_old.shape[0]))
+    pswitches = np.around(100 * nswitches / (real_area.sum()/100),decimals=2)
 
     df['Switches [ km2 ]'] = switches
     df['Switches [ % ]'] = 100 * switches / cells_prior

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -144,10 +144,6 @@ def write_files(sim, path):
             write_gtiff(ammaps[am], os.path.join(path, ammap_fname))
 
 
-
-
-
-
 def write_files_seperate(sim, path):
 
     # Write raw decision variables to seperate GeoTiffs
@@ -167,7 +163,8 @@ def write_files_seperate(sim, path):
         ag_man_rj_dict = {am: np.einsum('mrj -> rj', ammap) for am, ammap in sim.ag_man_dvars[yr_cal].items()}
         non_ag_rk = np.einsum('rk -> rk', sim.non_ag_dvars[yr_cal]) # Do nothing, just for consistency
 
-        # 2) Get the desc2code table
+        # 2) Get the desc2dvar table. 
+        #       desc is the land-use description, dvar is the decision variable corresponding to desc
         ag_dvar_map = tools.map_desc_to_dvar_index('Agriculture Landuse',sim.data.DESC2AGLU,ag_dvar_rj)
 
         ag_man_map = pd.concat([tools.map_desc_to_dvar_index(am,


### PR DESCRIPTION
Fix errors in cross/switch tables. 

- Fix the switch table of lu/lm, which were mistakenly out put as pd.Series
- Fix the ['Total %'] in switch table, which were mistakenly calculated as 'area_change / lumap.shape[0]'