### PR TITLE
Report data fully within write.py

### DIFF
--- a/luto/tools/report/create_html.py
+++ b/luto/tools/report/create_html.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import pandas as pd
 from glob import glob
+import argparse
 
 
 from tools.helper_func import add_data_2_html
@@ -11,14 +12,18 @@ from tools.helper_func import add_data_2_html
 #         setting up working variables             #
 ####################################################
 
-# setting up working directory to root dir
-if  __name__ == '__main__':
-    os.chdir('../../..')
+# # setting up working directory to root dir
+# if  __name__ == '__main__':
+#     os.chdir('../../..')
 
 # Get the output directory
-with open('output/working_dir.txt') as f:
-    RAW_DATA_ROOT = os.path.abspath(f.readline().strip())
-    RAW_DATA_ROOT = os.path.normpath(RAW_DATA_ROOT).replace("\\", "/")
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", type=str, required=True, help="Output directory path")
+args = parser.parse_args()
+
+RAW_DATA_ROOT = args.p
+RAW_DATA_ROOT = os.path.abspath(RAW_DATA_ROOT)
+RAW_DATA_ROOT = os.path.normpath(RAW_DATA_ROOT).replace("\\", "/")
 
 # Set the save directory    
 REPORT_DIR = f'{RAW_DATA_ROOT}/DATA_REPORT'

--- a/luto/tools/report/create_report_data.py
+++ b/luto/tools/report/create_report_data.py
@@ -2,6 +2,7 @@ import os
 import json
 import re
 import pandas as pd
+import argparse
 
 # import functions
 from tools import   get_AREA_am, get_AREA_lm, get_AREA_lu, get_GHG_emissions_by_crop_lvstk_df,\
@@ -17,13 +18,17 @@ from tools.helper_func import get_GHG_category, get_GHG_file_df, get_rev_cost,ta
 ####################################################
 
 # setting up working directory to root dir
-if  __name__ == '__main__':
-    os.chdir('../../..')
+# if  __name__ == '__main__':
+#     os.chdir('../../..')
 
 # Get the output directory
-with open('output/working_dir.txt') as f:
-    RAW_DATA_ROOT = os.path.abspath(f.readline().strip())
-    RAW_DATA_ROOT = os.path.normpath(RAW_DATA_ROOT).replace("\\", "/")
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", type=str, required=True, help="Output directory path")
+args = parser.parse_args()
+
+RAW_DATA_ROOT = args.p
+RAW_DATA_ROOT = os.path.abspath(RAW_DATA_ROOT)
+RAW_DATA_ROOT = os.path.normpath(RAW_DATA_ROOT).replace("\\", "/")
 
 # Set the save directory    
 SAVE_DIR = f'{RAW_DATA_ROOT}/DATA_REPORT/data'

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -62,10 +62,6 @@ def get_path(sim):
 
     # Create path name
     path = 'output/' + path + post
-    
-    # Write the path to output folder so that the report module knows where to look for the outputs
-    with open('output/working_dir.txt', 'w') as f:
-        f.write(path)
 
     # Get all paths 
     paths = [path]\
@@ -120,10 +116,13 @@ def write_outputs(sim, path):
     import subprocess
 
     # 1) Clean up the output CSVs 
-    subprocess.run(['python', 'luto/tools/report/create_report_data.py'])
+    result = subprocess.run(['python', 'luto/tools/report/create_report_data.py', '-p', path], capture_output=True, text=True)
+    print("\nError occurred:", result.stderr) if result.returncode != 0 else print("\nReport data:", result.stdout)
 
     # 2) Create the report
-    subprocess.run(['python', 'luto/tools/report/create_html.py'])
+    result = subprocess.run(['python', 'luto/tools/report/create_html.py', '-p', path], capture_output=True, text=True)
+    print("Error occurred:", result.stderr) if result.returncode != 0 else print("\nReport HTML:", result.stdout)
+
 
 
 


### PR DESCRIPTION
The 1) create report data, 2) create report HTML will be fully executed within write.py 

Before:
write.py --> output.txt (contain the output folder) --> create report data --> create report HTML
This will be hard to debug because the output folder is statically recorded in the output.txt

Now:
write.py --> create report data --> create report HTML
This will be easier for debugging because all report scripts are contained in the running time of the write.py

What happened?
we supplied the output folder as an argument to the subprocess.run
subprocess.run(['python', 'luto/tools/report/create_report_data.py', '-p', path]) 