### PR TITLE
Fixes for non ag LUs: disabling and doubling penalties

### DIFF
--- a/luto/economics/non_agricultural/transitions.py
+++ b/luto/economics/non_agricultural/transitions.py
@@ -600,7 +600,7 @@ def get_exclude_matrices(data: Data, lumap) -> np.ndarray:
     related to different non-agricultural land uses. The resulting matrix is a concatenation of these matrices
     along the k indexing.
     """
-    non_ag_x_matrices = {lu: np.zeros((data.NCELLS, data.N_NON_AG_LUS)) for lu in NON_AG_LAND_USES}
+    non_ag_x_matrices = {lu: np.zeros(data.NCELLS) for lu in NON_AG_LAND_USES}
 
     # Environmental plantings exclusions
     if NON_AG_LAND_USES['Environmental Plantings']:

--- a/luto/solvers/solver.py
+++ b/luto/solvers/solver.py
@@ -233,7 +233,7 @@ class LutoSolver:
             for k1, k2 in combinations(self._input_data.cells2non_ag_lu.get(r, []), 2):
                 # Penalty variables greater than or equal to min(X_non_ag_vars_kr[k1, r], X_non_ag_vars_kr[k2, r])
                 self.non_ag_doubling_vars_rkk[r, k1, k2] = self.gurobi_model.addVar(
-                    name=f"non_ag_doubling_penalty_{r}_{k1}_{k2}"
+                    name=f"non_ag_doubling_penalty_{r}_{k1}_{k2}", lb=0
                 )
                 self.Y_rkk[r, k1, k2] = self.gurobi_model.addVar(
                     name=f"Y_{r}_{k1}_{k2}"

--- a/luto/solvers/solver.py
+++ b/luto/solvers/solver.py
@@ -235,6 +235,9 @@ class LutoSolver:
                 self.non_ag_doubling_vars_rkk[r, k1, k2] = self.gurobi_model.addVar(
                     name=f"non_ag_doubling_penalty_{r}_{k1}_{k2}"
                 )
+                self.Y_rkk[r, k1, k2] = self.gurobi_model.addVar(
+                    name=f"Y_{r}_{k1}_{k2}"
+                )
 
     def _setup_objective(self):
         """


### PR DESCRIPTION
- Fixes the solver crashing when non-agricultural land uses are disabled
- Fixes the solver not choosing to use enough non-agricultural land uses when the non-ag doubling penalties are enabled