### PR TITLE
Net water yield implementation, water yield GHG effects, and timeseries water limits.

### DIFF
--- a/luto/data.py
+++ b/luto/data.py
@@ -1355,7 +1355,7 @@ class Data:
         np.ndarray: shape (NCELLS,)
         """
         dr_key = list(self.WATER_YIELD_DR_FILE.keys())[0]
-        return self.get_array_resfactor_applied(self.WATER_YIELD_DR_FILE[dr_key][yr_idx][self.LUMASK])
+        return self.get_array_resfactor_applied(self.WATER_YIELD_DR_FILE[dr_key][yr_idx])
     
     def get_water_dr_yield_for_year(self, yr_cal: int) -> np.ndarray:
         """
@@ -1377,7 +1377,7 @@ class Data:
         np.ndarray: shape (NCELLS,)
         """
         sr_key = list(self.WATER_YIELD_SR_FILE.keys())[0]
-        return self.get_array_resfactor_applied(self.WATER_YIELD_SR_FILE[sr_key][yr_idx][self.LUMASK])
+        return self.get_array_resfactor_applied(self.WATER_YIELD_SR_FILE[sr_key][yr_idx])
     
     def get_water_sr_yield_for_year(self, yr_cal: int) -> np.ndarray:
         """

--- a/luto/data.py
+++ b/luto/data.py
@@ -702,7 +702,7 @@ class Data:
 
         # Initialise container for water usage limits to avoid re-calculating the figures
         # during timeseries solves.
-        self.WATER_LIMITS_BY_YEAR = {}
+        self.WATER_LIMITS_BY_YEAR = None
 
         # Water requirements by land use -- LVSTK.
         wreq_lvstk_dry = pd.DataFrame()

--- a/luto/data.py
+++ b/luto/data.py
@@ -700,6 +700,10 @@ class Data:
         ###############################################################
         print("\tLoading water data...", flush=True)
 
+        # Initialise container for water usage limits to avoid re-calculating the figures
+        # during timeseries solves.
+        self.WATER_LIMITS_BY_YEAR = {}
+
         # Water requirements by land use -- LVSTK.
         wreq_lvstk_dry = pd.DataFrame()
         wreq_lvstk_irr = pd.DataFrame()

--- a/luto/economics/agricultural/cost.py
+++ b/luto/economics/agricultural/cost.py
@@ -183,7 +183,6 @@ def get_cost_lvstk(data: Data, lu, lm, yr_idx):
 
     # Water delivery costs equal drinking water plus irrigation water req per head * yield (head/ha)
     costs_w = (data.AGEC_LVSTK['WR_DRN', lvstype] + WR_IRR) * yield_pot
-    # TODO: check that the WP cost multiplier is applicable here.
     costs_w *= data.WATER_DELIVERY_PRICE * data.WP_COST_MULTS[yr_cal]  # $/ha
 
     # Convert costs to $ per cell including resfactor.

--- a/luto/economics/agricultural/water.py
+++ b/luto/economics/agricultural/water.py
@@ -19,13 +19,15 @@ Pure functions to calculate water use by lm, lu.
 """
 
 
-from typing import Dict
+from typing import Optional
 import numpy as np
+from collections import defaultdict
 
 import luto.settings as settings
 from luto.ag_managements import AG_MANAGEMENTS_TO_LAND_USES
 from luto.data import Data
 from luto.economics.agricultural.quantity import get_yield_pot, lvs_veg_types
+import luto.economics.non_agricultural.water as non_ag_water
 
 
 def get_wreq_matrices(data: Data, yr_idx):
@@ -308,7 +310,7 @@ def get_agtech_ei_effect_w_mrj(data, w_mrj, yr_idx):
     return new_w_mrj
 
 
-def get_agricultural_management_water_matrices(data: Data, w_mrj, yr_idx) -> Dict[str, np.ndarray]:
+def get_agricultural_management_water_matrices(data: Data, w_mrj, yr_idx) -> dict[str, np.ndarray]:
     asparagopsis_data = get_asparagopsis_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Asparagopsis taxiformis'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
     precision_agriculture_data = get_precision_agriculture_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Precision Agriculture'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
     eco_grazing_data = get_ecological_grazing_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Ecological Grazing'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))

--- a/luto/economics/agricultural/water.py
+++ b/luto/economics/agricultural/water.py
@@ -144,18 +144,18 @@ def get_water_net_yield_matrices(data: Data, yr_idx):
     return get_wyield_matrices(data, yr_idx) - get_wreq_matrices(data, yr_idx)
 
 
-def get_asparagopsis_effect_w_mrj(data: Data, w_mrj, yr_idx):
+def get_asparagopsis_effect_w_mrj(data: Data, yr_idx):
     """
-    Applies the effects of using asparagopsis to the water requirements data
+    Applies the effects of using asparagopsis to the water net yield data
     for all relevant agr. land uses.
 
     Args:
         data (object): The data object containing relevant information.
-        w_mrj (ndarray, <unit:ML/cell>): The water requirements data for all land uses.
+        w_mrj (ndarray, <unit:ML/cell>): The water net yield data for all land uses.
         yr_idx (int): The index of the year.
 
     Returns:
-        ndarray <unit:ML/cell>: The updated water requirements data with the effects of using asparagopsis.
+        ndarray <unit:ML/cell>: The updated water net yield data with the effects of using asparagopsis.
 
     Notes:
         Asparagopsis taxiformis has no effect on the water required.
@@ -167,8 +167,10 @@ def get_asparagopsis_effect_w_mrj(data: Data, w_mrj, yr_idx):
     lu_codes = np.array([data.DESC2AGLU[lu] for lu in land_uses])
     yr_cal = data.YR_CAL_BASE + yr_idx
 
+    wreq_mrj = get_wreq_matrices(data, yr_idx)
+
     # Set up the effects matrix
-    new_w_mrj = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
+    w_mrj_effect = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
 
     # Update values in the new matrix using the correct multiplier for each LU
     for lu_idx, lu in enumerate(land_uses):
@@ -177,23 +179,23 @@ def get_asparagopsis_effect_w_mrj(data: Data, w_mrj, yr_idx):
             j = lu_codes[lu_idx]
             # The effect is: new value = old value * multiplier - old value
             # E.g. a multiplier of .95 means a 5% reduction in quantity produced
-            new_w_mrj[:, :, lu_idx] = w_mrj[:, :, j] * (multiplier - 1)
+            w_mrj_effect[:, :, lu_idx] = wreq_mrj[:, :, j] * (multiplier - 1)
 
-    return new_w_mrj
+    return w_mrj_effect
 
 
-def get_precision_agriculture_effect_w_mrj(data: Data, w_mrj, yr_idx):
+def get_precision_agriculture_effect_w_mrj(data: Data, yr_idx):
     """
-    Applies the effects of using precision agriculture to the water requirements data
+    Applies the effects of using precision agriculture to the water net yield data
     for all relevant agricultural land uses.
 
     Parameters:
     - data: The data object containing relevant information for the calculation.
-    - w_mrj <unit:ML/cell>: The original water requirements data for different land uses.
+    - w_mrj <unit:ML/cell>: The original water net yield data for different land uses.
     - yr_idx: The index representing the year for which the calculation is performed.
 
     Returns:
-    - new_w_mrj <unit:ML/cell>: The updated water requirements data after applying precision agriculture effects.
+    - w_mrj_effect <unit:ML/cell>: The updated water net yield data after applying precision agriculture effects.
     """
     if not settings.AG_MANAGEMENTS['Precision Agriculture']:
         return np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
@@ -202,8 +204,10 @@ def get_precision_agriculture_effect_w_mrj(data: Data, w_mrj, yr_idx):
     lu_codes = np.array([data.DESC2AGLU[lu] for lu in land_uses])
     yr_cal = data.YR_CAL_BASE + yr_idx
 
+    wreq_mrj = get_wreq_matrices(data, yr_idx)
+
     # Set up the effects matrix
-    new_w_mrj = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
+    w_mrj_effect = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
 
     # Update values in the new matrix using the correct multiplier for each land use
     for lu_idx, lu in enumerate(land_uses):
@@ -212,23 +216,23 @@ def get_precision_agriculture_effect_w_mrj(data: Data, w_mrj, yr_idx):
             j = lu_codes[lu_idx]
             # The effect is: new value = old value * multiplier - old value
             # E.g. a multiplier of .95 means a 5% reduction in quantity produced
-            new_w_mrj[:, :, lu_idx] = w_mrj[:, :, j] * (multiplier - 1)
+            w_mrj_effect[:, :, lu_idx] = wreq_mrj[:, :, j] * (multiplier - 1)
 
-    return new_w_mrj
+    return w_mrj_effect
 
 
-def get_ecological_grazing_effect_w_mrj(data: Data, w_mrj, yr_idx):
+def get_ecological_grazing_effect_w_mrj(data: Data, yr_idx):
     """
-    Applies the effects of using ecological grazing to the water requirements data
+    Applies the effects of using ecological grazing to the water net yield data
     for all relevant agricultural land uses.
 
     Parameters:
     - data: The data object containing relevant information.
-    - w_mrj <unit:ML/cell>: The water requirements data for different land uses.
+    - w_mrj <unit:ML/cell>: The water net yield data for different land uses.
     - yr_idx: The index of the year.
 
     Returns:
-    - new_w_mrj <unit:ML/cell>: The updated water requirements data after applying ecological grazing effects.
+    - w_mrj_effect <unit:ML/cell>: The updated water net yield data after applying ecological grazing effects.
     """
     if not settings.AG_MANAGEMENTS['Ecological Grazing']:
         return np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
@@ -237,8 +241,10 @@ def get_ecological_grazing_effect_w_mrj(data: Data, w_mrj, yr_idx):
     lu_codes = np.array([data.DESC2AGLU[lu] for lu in land_uses])
     yr_cal = data.YR_CAL_BASE + yr_idx
 
+    wreq_mrj = get_wreq_matrices(data, yr_idx)
+
     # Set up the effects matrix
-    new_w_mrj = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
+    w_mrj_effect = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
 
     # Update values in the new matrix using the correct multiplier for each land use
     for lu_idx, lu in enumerate(land_uses):
@@ -247,46 +253,46 @@ def get_ecological_grazing_effect_w_mrj(data: Data, w_mrj, yr_idx):
             j = lu_codes[lu_idx]
             # The effect is: new value = old value * multiplier - old value
             # E.g. a multiplier of .95 means a 5% reduction in quantity produced
-            new_w_mrj[:, :, lu_idx] = w_mrj[:, :, j] * (multiplier - 1)
+            w_mrj_effect[:, :, lu_idx] = wreq_mrj[:, :, j] * (multiplier - 1)
 
-    return new_w_mrj
+    return w_mrj_effect
 
 
 def get_savanna_burning_effect_w_mrj(data):
-        """
-        Applies the effects of using savanna burning to the water requirements data
-        for all relevant agr. land uses.
-
-        Savanna burning does not affect water usage, so return an array of zeros.
-
-        Parameters:
-        - data: The input data object containing information about land uses and water requirements.
-
-        Returns:
-        - An array of zeros with dimensions (NLMS, NCELLS, nlus), where:
-            - NLMS: Number of land management systems
-            - NCELLS: Number of cells
-            - nlus: Number of land uses affected by savanna burning
-        """
-        if not settings.AG_MANAGEMENTS['Savanna Burning']:
-            return np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
-
-        nlus = len(AG_MANAGEMENTS_TO_LAND_USES['Savanna Burning'])
-        return np.zeros((data.NLMS, data.NCELLS, nlus))
-
-
-def get_agtech_ei_effect_w_mrj(data, w_mrj, yr_idx):
     """
-    Applies the effects of using AgTech EI to the water requirements data
+    Applies the effects of using savanna burning to the water net yield data
+    for all relevant agr. land uses.
+
+    Savanna burning does not affect water usage, so return an array of zeros.
+
+    Parameters:
+    - data: The input data object containing information about land uses and water net yield.
+
+    Returns:
+    - An array of zeros with dimensions (NLMS, NCELLS, nlus), where:
+        - NLMS: Number of land management systems
+        - NCELLS: Number of cells
+        - nlus: Number of land uses affected by savanna burning
+    """
+    if not settings.AG_MANAGEMENTS['Savanna Burning']:
+        return np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+
+    nlus = len(AG_MANAGEMENTS_TO_LAND_USES['Savanna Burning'])
+    return np.zeros((data.NLMS, data.NCELLS, nlus))
+
+
+def get_agtech_ei_effect_w_mrj(data, yr_idx):
+    """
+    Applies the effects of using AgTech EI to the water net yield data
     for all relevant agr. land uses.
 
     Parameters:
     - data: The data object containing relevant information.
-    - w_mrj <unit:ML/cell>: The water requirements data for all land uses.
+    - w_mrj <unit:ML/cell>: The water net yield data for all land uses.
     - yr_idx: The index of the year.
 
     Returns:
-    - new_w_mrj <unit:ML/cell>: The updated water requirements data with AgTech EI effects applied.
+    - w_mrj_effect <unit:ML/cell>: The updated water net yield data with AgTech EI effects applied.
     """
     if not settings.AG_MANAGEMENTS['AgTech EI']:
         return np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
@@ -295,8 +301,10 @@ def get_agtech_ei_effect_w_mrj(data, w_mrj, yr_idx):
     lu_codes = np.array([data.DESC2AGLU[lu] for lu in land_uses])
     yr_cal = data.YR_CAL_BASE + yr_idx
 
+    wreq_mrj = get_wreq_matrices(data, yr_idx)
+
     # Set up the effects matrix
-    new_w_mrj = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
+    w_mrj_effect = np.zeros((data.NLMS, data.NCELLS, len(land_uses))).astype(np.float32)
 
     # Update values in the new matrix using the correct multiplier for each LU
     for lu_idx, lu in enumerate(land_uses):
@@ -305,17 +313,37 @@ def get_agtech_ei_effect_w_mrj(data, w_mrj, yr_idx):
             j = lu_codes[lu_idx]
             # The effect is: new value = old value * multiplier - old value
             # E.g. a multiplier of .95 means a 5% reduction in quantity produced
-            new_w_mrj[:, :, lu_idx] = w_mrj[:, :, j] * (multiplier - 1)
+            w_mrj_effect[:, :, lu_idx] = wreq_mrj[:, :, j] * (multiplier - 1)
 
-    return new_w_mrj
+    return w_mrj_effect
 
 
-def get_agricultural_management_water_matrices(data: Data, w_mrj, yr_idx) -> dict[str, np.ndarray]:
-    asparagopsis_data = get_asparagopsis_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Asparagopsis taxiformis'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
-    precision_agriculture_data = get_precision_agriculture_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Precision Agriculture'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
-    eco_grazing_data = get_ecological_grazing_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['Ecological Grazing'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
-    sav_burning_data = get_savanna_burning_effect_w_mrj(data) if settings.AG_MANAGEMENTS['Savanna Burning'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
-    agtech_ei_data = get_agtech_ei_effect_w_mrj(data, w_mrj, yr_idx) if settings.AG_MANAGEMENTS['AgTech EI'] else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+def get_agricultural_management_water_matrices(data: Data, yr_idx) -> dict[str, np.ndarray]:
+    asparagopsis_data = (
+        get_asparagopsis_effect_w_mrj(data, yr_idx) 
+        if settings.AG_MANAGEMENTS['Asparagopsis taxiformis'] 
+        else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+    )
+    precision_agriculture_data = (
+        get_precision_agriculture_effect_w_mrj(data, yr_idx) 
+        if settings.AG_MANAGEMENTS['Precision Agriculture'] 
+        else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+    )
+    eco_grazing_data = (
+        get_ecological_grazing_effect_w_mrj(data, yr_idx) 
+        if settings.AG_MANAGEMENTS['Ecological Grazing'] 
+        else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+    )
+    sav_burning_data = (
+        get_savanna_burning_effect_w_mrj(data) 
+        if settings.AG_MANAGEMENTS['Savanna Burning'] 
+        else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+    )
+    agtech_ei_data = (
+        get_agtech_ei_effect_w_mrj(data, yr_idx) 
+        if settings.AG_MANAGEMENTS['AgTech EI'] 
+        else np.zeros((data.NLMS, data.NCELLS, data.N_AG_LUS))
+    )
 
     return {
         'Asparagopsis taxiformis': asparagopsis_data,
@@ -372,7 +400,7 @@ def calc_water_net_yield_by_region_in_year(
     yr_idx = yr_cal - data.YR_CAL_BASE
     ag_w_mrj = ag_w_mrj if ag_w_mrj is not None else get_water_net_yield_matrices(data, yr_idx)
     non_ag_w_rk = non_ag_w_rk if non_ag_w_rk is not None else non_ag_water.get_w_net_yield_matrix(data, yr_idx)
-    ag_man_w_mrj = ag_man_w_mrj if ag_man_w_mrj is not None else get_agricultural_management_water_matrices(data, ag_w_mrj, yr_idx)
+    ag_man_w_mrj = ag_man_w_mrj if ag_man_w_mrj is not None else get_agricultural_management_water_matrices(data, yr_idx)
     w_cc_impact = w_cc_impact if w_cc_impact is not None else get_water_ccimpact(data, yr_idx)
     
     # Calculate net yields

--- a/luto/economics/non_agricultural/transitions.py
+++ b/luto/economics/non_agricultural/transitions.py
@@ -992,7 +992,7 @@ def get_exclusions_riparian_plantings(data: Data, lumap) -> np.ndarray:
 
     # Exclude all cells used for natural land uses
     # TODO - this means natural LU cells cannot transition to agriculture/RP splits, even though
-    # they may transition to agriculture without the RP portion. Think about this before merging.
+    # they may transition to agriculture without the RP portion.
     exclude *= tools.get_exclusions_for_excluding_all_natural_cells(data, lumap)
 
     # Ensure cells being used for riparian plantings may retain that LU

--- a/luto/economics/non_agricultural/water.py
+++ b/luto/economics/non_agricultural/water.py
@@ -5,7 +5,7 @@ from luto.data import Data
 from luto import tools
 
 
-def get_wreq_matrix_env_planting(data: Data) -> np.ndarray:
+def get_w_net_yield_matrix_env_planting(data: Data) -> np.ndarray:
     """
     Get water requirements vector of environmental plantings.
 
@@ -20,10 +20,14 @@ def get_wreq_matrix_env_planting(data: Data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    return (data.WATER_YIELD_HIST_SR - data.WATER_YIELD_HIST_NL) * data.REAL_AREA
+    # Water requirements
+    wreq = (data.WATER_YIELD_HIST_SR - data.WATER_YIELD_HIST_NL) * data.REAL_AREA
+    # Water yield
+    wyield = data.WATER_YIELD_HIST_NL * data.REAL_AREA
+    return wyield - wreq
 
 
-def get_wreq_matrix_carbon_plantings_block(data) -> np.ndarray:
+def get_w_net_yield_matrix_carbon_plantings_block(data: Data) -> np.ndarray:
     """
     Get water requirements vector of carbon plantings (block arrangement).
 
@@ -37,11 +41,14 @@ def get_wreq_matrix_carbon_plantings_block(data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    # return get_wreq_matrix_env_planting(data)
-    return (data.WATER_YIELD_HIST_SR - data.WATER_YIELD_HIST_DR) * data.REAL_AREA
+    # Water requirements
+    wreq = (data.WATER_YIELD_HIST_SR - data.WATER_YIELD_HIST_DR) * data.REAL_AREA
+    # Water yield
+    wyield = data.WATER_YIELD_HIST_NL * data.REAL_AREA
+    return wyield - wreq
 
 
-def get_wreq_matrix_rip_planting(data: Data) -> np.ndarray:
+def get_w_net_yield_matrix_rip_planting(data: Data) -> np.ndarray:
     """
     Get water requirements vector of riparian plantings.
 
@@ -54,10 +61,10 @@ def get_wreq_matrix_rip_planting(data: Data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    return get_wreq_matrix_env_planting(data)
+    return get_w_net_yield_matrix_env_planting(data)
 
 
-def get_wreq_agroforestry_base(data: Data) -> np.ndarray:
+def get_w_net_yield_agroforestry_base(data: Data) -> np.ndarray:
     """
     Get water requirements vector of agroforestry.
 
@@ -70,7 +77,7 @@ def get_wreq_agroforestry_base(data: Data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    return get_wreq_matrix_env_planting(data)
+    return get_w_net_yield_matrix_env_planting(data)
 
 
 def get_wreq_sheep_agroforestry(
@@ -92,12 +99,12 @@ def get_wreq_sheep_agroforestry(
     sheep_j = tools.get_sheep_code(data)
 
     # Only use the dryland version of sheep
-    sheep_wreq = ag_w_mrj[0, :, sheep_j]
-    base_agroforestry_wreq = get_wreq_agroforestry_base(data)
+    sheep_w_net_yield = ag_w_mrj[0, :, sheep_j]
+    base_agroforestry_w_net_yield = get_w_net_yield_agroforestry_base(data)
 
     # Calculate contributions and return the sum
-    agroforestry_contr = base_agroforestry_wreq * agroforestry_x_r
-    sheep_contr = sheep_wreq * (1 - agroforestry_x_r)
+    agroforestry_contr = base_agroforestry_w_net_yield * agroforestry_x_r
+    sheep_contr = sheep_w_net_yield * (1 - agroforestry_x_r)
     return agroforestry_contr + sheep_contr
 
 
@@ -120,12 +127,12 @@ def get_wreq_beef_agroforestry(
     beef_j = tools.get_beef_code(data)
 
     # Only use the dryland version of beef
-    beef_wreq = ag_w_mrj[0, :, beef_j]
-    base_agroforestry_wreq = get_wreq_agroforestry_base(data)
+    beef_w_net_yield = ag_w_mrj[0, :, beef_j]
+    base_agroforestry_w_net_yield = get_w_net_yield_agroforestry_base(data)
 
     # Calculate contributions and return the sum
-    agroforestry_contr = base_agroforestry_wreq * agroforestry_x_r
-    beef_contr = beef_wreq * (1 - agroforestry_x_r)
+    agroforestry_contr = base_agroforestry_w_net_yield * agroforestry_x_r
+    beef_contr = beef_w_net_yield * (1 - agroforestry_x_r)
     return agroforestry_contr + beef_contr
 
 
@@ -139,7 +146,7 @@ def get_wreq_carbon_plantings_belt_base(data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    return get_wreq_matrix_carbon_plantings_block(data)
+    return get_w_net_yield_matrix_carbon_plantings_block(data)
 
 
 def get_wreq_sheep_carbon_plantings_belt(
@@ -161,12 +168,12 @@ def get_wreq_sheep_carbon_plantings_belt(
     sheep_j = tools.get_sheep_code(data)
 
     # Only use the dryland version of sheep
-    sheep_wreq = ag_w_mrj[0, :, sheep_j]
-    base_cp_wreq = get_wreq_carbon_plantings_belt_base(data)
+    sheep_w_net_yield = ag_w_mrj[0, :, sheep_j]
+    base_cp_w_net_yield = get_wreq_carbon_plantings_belt_base(data)
 
     # Calculate contributions and return the sum
-    cp_contr = base_cp_wreq * cp_belt_x_r
-    sheep_contr = sheep_wreq * (1 - cp_belt_x_r)
+    cp_contr = base_cp_w_net_yield * cp_belt_x_r
+    sheep_contr = sheep_w_net_yield * (1 - cp_belt_x_r)
     return cp_contr + sheep_contr
 
 
@@ -189,12 +196,12 @@ def get_wreq_beef_carbon_plantings_belt(
     beef_j = tools.get_beef_code(data)
 
     # Only use the dryland version of beef
-    beef_wreq = ag_w_mrj[0, :, beef_j]
-    base_cp_wreq = get_wreq_carbon_plantings_belt_base(data)
+    beef_w_net_yield = ag_w_mrj[0, :, beef_j]
+    base_cp_w_net_yield = get_wreq_carbon_plantings_belt_base(data)
 
     # Calculate contributions and return the sum
-    cp_contr = base_cp_wreq * cp_belt_x_r
-    beef_contr = beef_wreq * (1 - cp_belt_x_r)
+    cp_contr = base_cp_w_net_yield * cp_belt_x_r
+    beef_contr = beef_w_net_yield * (1 - cp_belt_x_r)
     return cp_contr + beef_contr
 
 
@@ -208,10 +215,10 @@ def get_wreq_matrix_beccs(data) -> np.ndarray:
     -------
     1-D array, indexed by cell.
     """
-    return get_wreq_matrix_carbon_plantings_block(data)
+    return get_w_net_yield_matrix_carbon_plantings_block(data)
 
 
-def get_wreq_matrix(data: Data, ag_w_mrj: np.ndarray, lumap: np.ndarray) -> np.ndarray:
+def get_w_net_yield_matrix(data: Data, ag_w_mrj: np.ndarray, lumap: np.ndarray) -> np.ndarray:
     """
     Get the water requirements matrix for all non-agricultural land uses.
 
@@ -233,10 +240,10 @@ def get_wreq_matrix(data: Data, ag_w_mrj: np.ndarray, lumap: np.ndarray) -> np.n
 
     # reshape each non-agricultural matrix to be indexed (r, k) and concatenate on the k indexing
     if NON_AG_LAND_USES['Environmental Plantings']:
-        non_agr_wreq_matrices['Environmental Plantings'] = get_wreq_matrix_env_planting(data).reshape((data.NCELLS, 1))
+        non_agr_wreq_matrices['Environmental Plantings'] = get_w_net_yield_matrix_env_planting(data).reshape((data.NCELLS, 1))
 
     if NON_AG_LAND_USES['Riparian Plantings']:
-        non_agr_wreq_matrices['Riparian Plantings'] = get_wreq_matrix_rip_planting(data).reshape((data.NCELLS, 1))
+        non_agr_wreq_matrices['Riparian Plantings'] = get_w_net_yield_matrix_rip_planting(data).reshape((data.NCELLS, 1))
 
     if NON_AG_LAND_USES['Sheep Agroforestry']:
         non_agr_wreq_matrices['Sheep Agroforestry'] = get_wreq_sheep_agroforestry(data, ag_w_mrj, agroforestry_x_r).reshape((data.NCELLS, 1))
@@ -245,7 +252,7 @@ def get_wreq_matrix(data: Data, ag_w_mrj: np.ndarray, lumap: np.ndarray) -> np.n
         non_agr_wreq_matrices['Beef Agroforestry'] = get_wreq_beef_agroforestry(data, ag_w_mrj, agroforestry_x_r).reshape((data.NCELLS, 1))
 
     if NON_AG_LAND_USES['Carbon Plantings (Block)']:
-        non_agr_wreq_matrices['Carbon Plantings (Block)'] = get_wreq_matrix_carbon_plantings_block(data).reshape((data.NCELLS, 1))
+        non_agr_wreq_matrices['Carbon Plantings (Block)'] = get_w_net_yield_matrix_carbon_plantings_block(data).reshape((data.NCELLS, 1))
 
     if NON_AG_LAND_USES['Sheep Carbon Plantings (Belt)']:
         non_agr_wreq_matrices['Sheep Carbon Plantings (Belt)'] = get_wreq_sheep_carbon_plantings_belt(data, ag_w_mrj, cp_belt_x_r).reshape((data.NCELLS, 1))

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -328,15 +328,8 @@ SOC_AMORTISATION = 15
 
 
 # Water use limits and parameters *******************************
-WATER_USE_LIMITS = 'on'               # 'on' or 'off'
-WATER_LIMITS_TYPE = 'water_stress'    # 'water_stress' or 'pct_ag'
+WATER_NET_YIELD_LIMITS = 'on'               # 'on' or 'off'
 
-# If WATER_LIMITS_TYPE = 'pct_ag'...       
-# Set reduction in water use as percentage of 2010 irrigation water use
-WATER_USE_REDUCTION_PERCENTAGE = 0  
-
-# If WATER_LIMITS_TYPE = 'water_stress'...                                           
-# Safe and just Earth system boundaries says 0.2 inclusive of domestic/industrial https://www.nature.com/articles/s41586-023-06083-8  
 WATER_STRESS_FRACTION = 0.2          
 
 # Regionalisation to enforce water use limits by

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -330,6 +330,8 @@ SOC_AMORTISATION = 15
 # Water use limits and parameters *******************************
 WATER_NET_YIELD_LIMITS = 'on'               # 'on' or 'off'
 
+WATER_LIMITS_TARGET_YEAR = 2030
+
 WATER_STRESS_FRACTION = 0.2          
 
 # Regionalisation to enforce water use limits by

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -334,14 +334,13 @@ WATER_NET_YIELD_LIMITS = 'on'               # 'on' or 'off'
 WATER_REGION_DEF = 'Drainage Division'                 # 'River Region' or 'Drainage Division' Bureau of Meteorology GeoFabric definition
 
 # Water net yield targets: the value represents the proportion of the historical water yields 
-# that the net yield must exceed in a given year. Base year (2010) uses base year net yields as targets
-# (unless otherwise specified). Everything past the latest year specified uses the target figure 
-# for the latest year.
+# that the net yield must exceed in a given year. Base year (2010) uses base year net yields as targets. 
+# Everything past the latest year specified uses the target figure for the latest year.
 # Safe and just Earth system boundaries says water stress of 0.2 (yield target of 0.8) is inclusive of 
 # domestic/industrial: https://www.nature.com/articles/s41586-023-06083-8
 WATER_YIELD_TARGETS = {
                         2030: 0.8,
-                        2100: 1,
+                        2100: 0.8,
                       }
 
 

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -330,13 +330,19 @@ SOC_AMORTISATION = 15
 # Water use limits and parameters *******************************
 WATER_NET_YIELD_LIMITS = 'on'               # 'on' or 'off'
 
-WATER_LIMITS_TARGET_YEAR = 2030
-
-# Safe and just Earth system boundaries says 0.2 inclusive of domestic/industrial https://www.nature.com/articles/s41586-023-06083-8
-WATER_STRESS_FRACTION = 0.2          
-
 # Regionalisation to enforce water use limits by
 WATER_REGION_DEF = 'Drainage Division'                 # 'River Region' or 'Drainage Division' Bureau of Meteorology GeoFabric definition
+
+# Water net yield targets: the value represents the proportion of the historical water yields 
+# that the net yield must exceed in a given year. Base year (2010) uses base year net yields as targets
+# (unless otherwise specified). Everything past the latest year specified uses the target figure 
+# for the latest year.
+# Safe and just Earth system boundaries says water stress of 0.2 (yield target of 0.8) is inclusive of 
+# domestic/industrial: https://www.nature.com/articles/s41586-023-06083-8
+WATER_YIELD_TARGETS = {
+                        2030: 0.8,
+                        2100: 1,
+                      }
 
 
 # Biodiversity limits and parameters *******************************

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -119,10 +119,10 @@ PENALTY = 1e5
 # Geographical raster writing parameters
 # ---------------------------------------------------------------------------- #
 
-WRITE_OUTPUT_GEOTIFFS = False    # Write GeoTiffs to output directory: True or False
+WRITE_OUTPUT_GEOTIFFS = True    # Write GeoTiffs to output directory: True or False
 WRITE_FULL_RES_MAPS = False     # Write GeoTiffs at full or resfactored resolution: True or False
-PARALLEL_WRITE = False           # If to use parallel processing to write GeoTiffs: True or False
-WRITE_THREADS = 8              # The Threads to use for map making, only work with PARALLEL_WRITE = True
+PARALLEL_WRITE = True           # If to use parallel processing to write GeoTiffs: True or False
+WRITE_THREADS = 50              # The Threads to use for map making, only work with PARALLEL_WRITE = True
 
 # ---------------------------------------------------------------------------- #
 # Gurobi parameters
@@ -152,7 +152,7 @@ NUMERIC_FOCUS = 0   # Controls the degree to which the code attempts to detect a
 BARHOMOGENOUS = -1  # Useful for recognizing infeasibility or unboundedness. At the default setting (-1), it is only used when barrier solves a node relaxation for a MIP model. 0 = off, 1 = on. It is a bit slower than the default algorithm (3x slower in testing).
 
 # Number of threads to use in parallel algorithms (e.g., barrier)
-THREADS = 8
+THREADS = 50
 
 
 # ---------------------------------------------------------------------------- #
@@ -332,6 +332,7 @@ WATER_NET_YIELD_LIMITS = 'on'               # 'on' or 'off'
 
 WATER_LIMITS_TARGET_YEAR = 2030
 
+# Safe and just Earth system boundaries says 0.2 inclusive of domestic/industrial https://www.nature.com/articles/s41586-023-06083-8
 WATER_STRESS_FRACTION = 0.2          
 
 # Regionalisation to enforce water use limits by

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -119,10 +119,10 @@ PENALTY = 1e5
 # Geographical raster writing parameters
 # ---------------------------------------------------------------------------- #
 
-WRITE_OUTPUT_GEOTIFFS = True    # Write GeoTiffs to output directory: True or False
+WRITE_OUTPUT_GEOTIFFS = False    # Write GeoTiffs to output directory: True or False
 WRITE_FULL_RES_MAPS = False     # Write GeoTiffs at full or resfactored resolution: True or False
-PARALLEL_WRITE = True           # If to use parallel processing to write GeoTiffs: True or False
-WRITE_THREADS = 50              # The Threads to use for map making, only work with PARALLEL_WRITE = True
+PARALLEL_WRITE = False           # If to use parallel processing to write GeoTiffs: True or False
+WRITE_THREADS = 8              # The Threads to use for map making, only work with PARALLEL_WRITE = True
 
 # ---------------------------------------------------------------------------- #
 # Gurobi parameters
@@ -152,7 +152,7 @@ NUMERIC_FOCUS = 0   # Controls the degree to which the code attempts to detect a
 BARHOMOGENOUS = -1  # Useful for recognizing infeasibility or unboundedness. At the default setting (-1), it is only used when barrier solves a node relaxation for a MIP model. 0 = off, 1 = on. It is a bit slower than the default algorithm (3x slower in testing).
 
 # Number of threads to use in parallel algorithms (e.g., barrier)
-THREADS = 50
+THREADS = 8
 
 
 # ---------------------------------------------------------------------------- #

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -64,6 +64,8 @@ class SolverInputData:
     ag_man_limits: dict             # Agricultural management options' adoption limits.
     ag_man_lb_mrj: dict             # Agricultural management options' lower bounds.
 
+    w_ccimpact: dict[int, float]    # Climate change impacts of water dict.
+
     offland_ghg: np.ndarray         # GHG emissions from off-land commodities.
 
     lu2pr_pj: np.ndarray            # Conversion matrix: land-use to product(s).
@@ -193,9 +195,14 @@ def get_non_ag_g_rk(data: Data, ag_g_mrj, base_year):
 
 
 def get_ag_w_mrj(data: Data, target_index):
-    print('Getting agricultural water requirement matrices...', flush = True)
-    output = ag_water.get_wreq_matrices(data, target_index)
+    print('Getting agricultural water net yield matrices...', flush = True)
+    output = ag_water.get_water_net_yield_matrices(data, target_index)
     return output.astype(np.float32)
+
+
+def get_w_ccimpact(data: Data, target_index):
+    print('Getting water climate change impact figures...', flush = True)
+    return ag_water.get_water_ccimpact(data, target_index)
 
 
 def get_ag_b_mrj(data: Data):
@@ -341,7 +348,7 @@ def get_limits(data: Data, target: int):
     # Limits is a dictionary with heterogeneous value sets.
     limits = {}
     
-    if settings.WATER_USE_LIMITS == 'on': limits['water'] = ag_water.get_wuse_limits(data)
+    if settings.WATER_NET_YIELD_LIMITS == 'on': limits['water'] = ag_water.get_water_net_yield_limits(data)
     if settings.GHG_EMISSIONS_LIMITS == 'on':  limits['ghg'] = ag_ghg.get_ghg_limits(data, target)
     
     # If biodiversity limits are not turned on, set the limit to 0.
@@ -399,6 +406,7 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         ag_man_b_mrj=get_ag_man_biodiversity(data),
         ag_man_limits=get_ag_man_limits(data, target_index),
         ag_man_lb_mrj=get_ag_man_lb_mrj(data, base_year),
+        w_ccimpact=get_w_ccimpact(data, target_index),
         offland_ghg=data.OFF_LAND_GHG_EMISSION_C[target_index],
         lu2pr_pj=data.LU2PR,
         pr2cm_cp=data.PR2CM,

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
+from typing import Optional, Any
 import numpy as np
 
 from luto import settings
@@ -343,16 +344,37 @@ def get_ag_man_limits(data: Data, target_index):
     return output
 
 
-def get_limits(data: Data, target: int):
+def get_limits(
+    data: Data,
+    yr_cal: int,
+    ag_w_mrj: Optional[np.ndarray] = None,
+    non_ag_w_rk: Optional[np.ndarray] = None,
+    ag_man_w_mrj: Optional[dict[str, np.ndarray]] = None,
+    w_cc_impact: Optional[dict[int, float]] = None,
+) -> dict[str, Any]:
+    """
+    Gets the following limits for the solve:
+    - Water net yield limits
+    - GHG limits
+    - Biodiversity limits
+    """
     print('Getting environmental limits...', flush = True)
     # Limits is a dictionary with heterogeneous value sets.
     limits = {}
     
-    if settings.WATER_NET_YIELD_LIMITS == 'on': limits['water'] = ag_water.get_water_net_yield_limits(data)
-    if settings.GHG_EMISSIONS_LIMITS == 'on':  limits['ghg'] = ag_ghg.get_ghg_limits(data, target)
+    if settings.WATER_NET_YIELD_LIMITS == 'on':
+        limits['water'] = ag_water.get_water_net_yield_limits(
+            data, yr_cal, ag_w_mrj, non_ag_w_rk, ag_man_w_mrj, w_cc_impact,
+        )
+    if settings.GHG_EMISSIONS_LIMITS == 'on':
+        limits['ghg'] = ag_ghg.get_ghg_limits(data, yr_cal)
     
     # If biodiversity limits are not turned on, set the limit to 0.
-    limits['biodiversity'] = ag_biodiversity.get_biodiversity_limits(data, target) if settings.BIODIVERSITY_LIMITS == 'on' else 0 
+    limits['biodiversity'] = (
+        ag_biodiversity.get_biodiversity_limits(data, yr_cal)
+        if settings.BIODIVERSITY_LIMITS == 'on'
+        else 0
+    )
     
     return limits
 
@@ -376,6 +398,10 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         ag_x_mrj, ag_c_mrj, ag_t_mrj, ag_r_mrj
     )
 
+    non_ag_w_rk = get_non_ag_w_rk(data, ag_w_mrj, base_year)
+    ag_man_w_mrj = get_ag_man_water(data, target_index, ag_w_mrj)
+    w_ccimpact = get_w_ccimpact(data, target_index)
+
     return SolverInputData(
         ag_t_mrj=ag_t_mrj,
         ag_c_mrj=ag_c_mrj,
@@ -392,7 +418,7 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         non_ag_c_rk=get_non_ag_c_rk(data, ag_c_mrj, base_year, target_year),
         non_ag_r_rk=get_non_ag_r_rk(data, ag_r_mrj, base_year, target_year),
         non_ag_g_rk=get_non_ag_g_rk(data, ag_g_mrj, base_year),
-        non_ag_w_rk=get_non_ag_w_rk(data, ag_w_mrj, base_year),
+        non_ag_w_rk=non_ag_w_rk,
         non_ag_b_rk=get_non_ag_b_rk(data, ag_b_mrj, base_year),
         non_ag_x_rk=get_non_ag_x_rk(data, ag_x_mrj, base_year),
         non_ag_q_crk=get_non_ag_q_crk(data, ag_q_mrp, base_year),
@@ -402,15 +428,15 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         ag_man_q_mrp=get_ag_man_quantity(data, target_index, ag_q_mrp),
         ag_man_r_mrj=get_ag_man_revenue(data, target_index, ag_r_mrj),
         ag_man_t_mrj=get_ag_man_transitions(data, target_index, ag_t_mrj),
-        ag_man_w_mrj=get_ag_man_water(data, target_index, ag_w_mrj),
+        ag_man_w_mrj=ag_man_w_mrj,
         ag_man_b_mrj=get_ag_man_biodiversity(data),
         ag_man_limits=get_ag_man_limits(data, target_index),
         ag_man_lb_mrj=get_ag_man_lb_mrj(data, base_year),
-        w_ccimpact=get_w_ccimpact(data, target_index),
+        w_ccimpact=w_ccimpact,
         offland_ghg=data.OFF_LAND_GHG_EMISSION_C[target_index],
         lu2pr_pj=data.LU2PR,
         pr2cm_cp=data.PR2CM,
-        limits=get_limits(data, target_year),
+        limits=get_limits(data, target_year, ag_w_mrj, non_ag_w_rk, ag_man_w_mrj, w_ccimpact),
         desc2aglu=data.DESC2AGLU,
         resmult=data.RESMULT,
     )

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -326,9 +326,9 @@ def get_ag_man_transitions(data: Data, target_index, ag_t_mrj):
     return output
 
 
-def get_ag_man_water(data: Data, target_index, ag_w_mrj):
+def get_ag_man_water(data: Data, target_index):
     print('Getting agricultural management options\' water requirement effects...', flush = True)
-    output = ag_water.get_agricultural_management_water_matrices(data, ag_w_mrj, target_index)
+    output = ag_water.get_agricultural_management_water_matrices(data, target_index)
     return output
 
 
@@ -399,7 +399,7 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
     )
 
     non_ag_w_rk = get_non_ag_w_rk(data, ag_w_mrj, base_year)
-    ag_man_w_mrj = get_ag_man_water(data, target_index, ag_w_mrj)
+    ag_man_w_mrj = get_ag_man_water(data, target_index)
     w_ccimpact = get_w_ccimpact(data, target_index)
 
     return SolverInputData(

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -213,7 +213,7 @@ def get_ag_b_mrj(data: Data):
 
 def get_non_ag_w_rk(data: Data, ag_w_mrj: np.ndarray, base_year):
     print('Getting non-agricultural water requirement matrices...', flush = True)
-    output = non_ag_water.get_wreq_matrix(data, ag_w_mrj, data.lumaps[base_year])
+    output = non_ag_water.get_w_net_yield_matrix(data, ag_w_mrj, data.lumaps[base_year])
     return output.astype(np.float32)
 
 

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -345,12 +345,7 @@ def get_ag_man_limits(data: Data, target_index):
 
 
 def get_limits(
-    data: Data,
-    yr_cal: int,
-    ag_w_mrj: Optional[np.ndarray] = None,
-    non_ag_w_rk: Optional[np.ndarray] = None,
-    ag_man_w_mrj: Optional[dict[str, np.ndarray]] = None,
-    w_cc_impact: Optional[dict[int, float]] = None,
+    data: Data, yr_cal: int,
 ) -> dict[str, Any]:
     """
     Gets the following limits for the solve:
@@ -363,9 +358,8 @@ def get_limits(
     limits = {}
     
     if settings.WATER_NET_YIELD_LIMITS == 'on':
-        limits['water'] = ag_water.get_water_net_yield_limits(
-            data, yr_cal, ag_w_mrj, non_ag_w_rk, ag_man_w_mrj, w_cc_impact,
-        )
+        limits['water'] = ag_water.get_water_net_yield_limits(data, yr_cal)
+    
     if settings.GHG_EMISSIONS_LIMITS == 'on':
         limits['ghg'] = ag_ghg.get_ghg_limits(data, yr_cal)
     
@@ -398,10 +392,6 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         ag_x_mrj, ag_c_mrj, ag_t_mrj, ag_r_mrj
     )
 
-    non_ag_w_rk = get_non_ag_w_rk(data, ag_w_mrj, base_year)
-    ag_man_w_mrj = get_ag_man_water(data, target_index)
-    w_ccimpact = get_w_ccimpact(data, target_index)
-
     return SolverInputData(
         ag_t_mrj=ag_t_mrj,
         ag_c_mrj=ag_c_mrj,
@@ -418,7 +408,7 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         non_ag_c_rk=get_non_ag_c_rk(data, ag_c_mrj, base_year, target_year),
         non_ag_r_rk=get_non_ag_r_rk(data, ag_r_mrj, base_year, target_year),
         non_ag_g_rk=get_non_ag_g_rk(data, ag_g_mrj, base_year),
-        non_ag_w_rk=non_ag_w_rk,
+        non_ag_w_rk=get_non_ag_w_rk(data, ag_w_mrj, base_year),
         non_ag_b_rk=get_non_ag_b_rk(data, ag_b_mrj, base_year),
         non_ag_x_rk=get_non_ag_x_rk(data, ag_x_mrj, base_year),
         non_ag_q_crk=get_non_ag_q_crk(data, ag_q_mrp, base_year),
@@ -428,15 +418,15 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         ag_man_q_mrp=get_ag_man_quantity(data, target_index, ag_q_mrp),
         ag_man_r_mrj=get_ag_man_revenue(data, target_index, ag_r_mrj),
         ag_man_t_mrj=get_ag_man_transitions(data, target_index, ag_t_mrj),
-        ag_man_w_mrj=ag_man_w_mrj,
+        ag_man_w_mrj=get_ag_man_water(data, target_index),
         ag_man_b_mrj=get_ag_man_biodiversity(data),
         ag_man_limits=get_ag_man_limits(data, target_index),
         ag_man_lb_mrj=get_ag_man_lb_mrj(data, base_year),
-        w_ccimpact=w_ccimpact,
+        w_ccimpact=get_w_ccimpact(data, target_index),
         offland_ghg=data.OFF_LAND_GHG_EMISSION_C[target_index],
         lu2pr_pj=data.LU2PR,
         pr2cm_cp=data.PR2CM,
-        limits=get_limits(data, target_year, ag_w_mrj, non_ag_w_rk, ag_man_w_mrj, w_ccimpact),
+        limits=get_limits(data, target_year),
         desc2aglu=data.DESC2AGLU,
         resmult=data.RESMULT,
     )

--- a/luto/solvers/solver.py
+++ b/luto/solvers/solver.py
@@ -551,7 +551,7 @@ class LutoSolver:
         self.water_limit_constraints_r = defaultdict(list)
 
         # Ensure water use remains below limit for each region
-        for region, (reg_name, w_net_yield_total, w_net_yield_limit, ind) in self._input_data.limits["water"].items():
+        for region, (reg_name, _, w_net_yield_limit, ind) in self._input_data.limits["water"].items():
             reg_ccimpact = self._input_data.w_ccimpact[region]
 
             ag_contr = gp.quicksum(

--- a/luto/tools/report/create_report_data.py
+++ b/luto/tools/report/create_report_data.py
@@ -1081,8 +1081,8 @@ def save_report_data(raw_data_dir:str):
         water_df_separate = water_df_separate.replace(RENAME_AM_NON_AG)
         
 
-        # Plot_5-1: Water use compared to limite (%)
-        water_df_total_pct = water_df_total.query('Variable == "PROPORTION_ALL_%" ')
+        # Plot_5-1: Water net yield compared to limite (%)
+        water_df_total_pct = water_df_total.query('Variable == "PROPORTION_LIMIT_%" ')
         water_df_total_pct_wide = water_df_total_pct\
                                     .groupby(['REGION_NAME'])[['Year','Value (ML)']]\
                                     .apply(lambda x: list(map(list,zip(x['Year'],x['Value (ML)']))))\
@@ -1090,10 +1090,10 @@ def save_report_data(raw_data_dir:str):
                                     
         water_df_total_pct_wide.columns = ['name','data']
         water_df_total_pct_wide['type'] = 'spline'
-        water_df_total_pct_wide.to_json(f'{SAVE_DIR}/water_1_percent_to_limit.json',orient='records')
+        water_df_total_pct_wide.to_json(f'{SAVE_DIR}/water_1_percent_of_limit.json',orient='records')
 
 
-        # Plot_5-2: Water use compared to limite (ML)
+        # Plot_5-2: Water net yield compared to limite (ML)
         water_df_total_yield = water_df_total.query('Variable == "TOT_WATER_NET_YIELD_ML" ')
         water_df_total_yield_wide = water_df_total_yield\
                                     .groupby(['REGION_NAME'])[['Year','Value (ML)']]\

--- a/luto/tools/report/create_report_data.py
+++ b/luto/tools/report/create_report_data.py
@@ -1072,7 +1072,7 @@ def save_report_data(raw_data_dir:str):
     #                     5) Water                     #
     ####################################################
     
-    if settings.WATER_USE_LIMITS == 'on':
+    if settings.WATER_NET_YIELD_LIMITS == 'on':
         water_df_total = files.query('category == "water" and year_types == "single_year" and ~base_name.str.contains("separate")').reset_index(drop=True)
         water_df_total = pd.concat([pd.read_csv(path) for path in water_df_total['path']], ignore_index=True)
         
@@ -1106,29 +1106,29 @@ def save_report_data(raw_data_dir:str):
         
         
         # Plot_5-3: Water use by sector (ML)
-        water_df_separate_lu_type = water_df_separate.groupby(['Year','Landuse Type']).sum(numeric_only=True)[['Water Use (ML)']].reset_index()
+        water_df_separate_lu_type = water_df_separate.groupby(['Year','Landuse Type']).sum(numeric_only=True)[['Water Net Yield (ML)']].reset_index()
         water_df_net = water_df_separate.groupby('Year').sum(numeric_only=True).reset_index()
 
         water_df_separate_lu_type = water_df_separate_lu_type\
-            .groupby(['Landuse Type'])[['Landuse Type','Year','Water Use (ML)']]\
-            .apply(lambda x:list(map(list,zip(x['Year'],x['Water Use (ML)']))))\
+            .groupby(['Landuse Type'])[['Landuse Type','Year','Water Net Yield (ML)']]\
+            .apply(lambda x:list(map(list,zip(x['Year'],x['Water Net Yield (ML)']))))\
             .reset_index()
             
         water_df_separate_lu_type.columns = ['name','data']
         water_df_separate_lu_type['type'] = 'column'
 
-        water_df_separate_lu_type.loc[len(water_df_separate_lu_type)] = ['Net Volume', list(map(list,zip(water_df_net['Year'],water_df_net['Water Use (ML)']))), 'line']
+        water_df_separate_lu_type.loc[len(water_df_separate_lu_type)] = ['Net Volume', list(map(list,zip(water_df_net['Year'],water_df_net['Water Net Yield (ML)']))), 'line']
 
         water_df_separate_lu_type.to_json(f'{SAVE_DIR}/water_3_volume_by_sector.json',orient='records')
 
 
 
         # Plot_5-4: Water use by landuse (ML)
-        water_df_seperate_lu = water_df_separate.groupby(['Year','Landuse']).sum()[['Water Use (ML)']].reset_index()
+        water_df_seperate_lu = water_df_separate.groupby(['Year','Landuse']).sum()[['Water Net Yield (ML)']].reset_index()
         
         water_df_seperate_lu_wide = water_df_seperate_lu\
-                                        .groupby(['Landuse'])[['Year','Water Use (ML)']]\
-                                        .apply(lambda x: list(map(list,zip(x['Year'],x['Water Use (ML)']))))\
+                                        .groupby(['Landuse'])[['Year','Water Net Yield (ML)']]\
+                                        .apply(lambda x: list(map(list,zip(x['Year'],x['Water Net Yield (ML)']))))\
                                         .reset_index()
                                         
         water_df_seperate_lu_wide.columns = ['name','data']
@@ -1140,11 +1140,11 @@ def save_report_data(raw_data_dir:str):
         
         
         # Plot_5-5: Water use by Water_supply (ML)
-        water_df_seperate_irr = water_df_separate.groupby(['Year','Water_supply']).sum()[['Water Use (ML)']].reset_index()
+        water_df_seperate_irr = water_df_separate.groupby(['Year','Water_supply']).sum()[['Water Net Yield (ML)']].reset_index()
         
         water_df_seperate_irr_wide = water_df_seperate_irr\
-                                        .groupby(['Water_supply'])[['Year','Water Use (ML)']]\
-                                        .apply(lambda x: list(map(list,zip(x['Year'],x['Water Use (ML)']))))\
+                                        .groupby(['Water_supply'])[['Year','Water Net Yield (ML)']]\
+                                        .apply(lambda x: list(map(list,zip(x['Year'],x['Water Net Yield (ML)']))))\
                                         .reset_index()
                                         
         water_df_seperate_irr_wide.columns = ['name','data']

--- a/luto/tools/report/create_report_data.py
+++ b/luto/tools/report/create_report_data.py
@@ -1094,18 +1094,19 @@ def save_report_data(raw_data_dir:str):
 
 
         # Plot_5-2: Water use compared to limite (ML)
-        water_df_total_vol = water_df_total.query('Variable == "TOT_WATER_REQ_ML" ')
-        water_df_total_vol_wide = water_df_total_vol\
+        water_df_total_yield = water_df_total.query('Variable == "TOT_WATER_NET_YIELD_ML" ')
+        water_df_total_yield_wide = water_df_total_yield\
                                     .groupby(['REGION_NAME'])[['Year','Value (ML)']]\
                                     .apply(lambda x: list(map(list,zip(x['Year'],x['Value (ML)']))))\
                                     .reset_index()
-        water_df_total_vol_wide.columns = ['name','data']
-        water_df_total_vol_wide['type'] = 'spline'
-        water_df_total_vol_wide.to_json(f'{SAVE_DIR}/water_2_volume_to_limit.json',orient='records')                        
+
+        water_df_total_yield_wide.columns = ['name','data']
+        water_df_total_yield_wide['type'] = 'spline'
+        water_df_total_yield_wide.to_json(f'{SAVE_DIR}/water_2_yield_to_limit.json',orient='records')                        
         
         
         
-        # Plot_5-3: Water use by sector (ML)
+        # Plot_5-3: Water net yield by sector (ML)
         water_df_separate_lu_type = water_df_separate.groupby(['Year','Landuse Type']).sum(numeric_only=True)[['Water Net Yield (ML)']].reset_index()
         water_df_net = water_df_separate.groupby('Year').sum(numeric_only=True).reset_index()
 
@@ -1119,11 +1120,11 @@ def save_report_data(raw_data_dir:str):
 
         water_df_separate_lu_type.loc[len(water_df_separate_lu_type)] = ['Net Volume', list(map(list,zip(water_df_net['Year'],water_df_net['Water Net Yield (ML)']))), 'line']
 
-        water_df_separate_lu_type.to_json(f'{SAVE_DIR}/water_3_volume_by_sector.json',orient='records')
+        water_df_separate_lu_type.to_json(f'{SAVE_DIR}/water_3_net_yield_by_sector.json',orient='records')
 
 
 
-        # Plot_5-4: Water use by landuse (ML)
+        # Plot_5-4: Water net yield by landuse (ML)
         water_df_seperate_lu = water_df_separate.groupby(['Year','Landuse']).sum()[['Water Net Yield (ML)']].reset_index()
         
         water_df_seperate_lu_wide = water_df_seperate_lu\
@@ -1136,10 +1137,10 @@ def save_report_data(raw_data_dir:str):
         water_df_seperate_lu_wide = water_df_seperate_lu_wide.set_index('name').reindex(LANDUSE_ALL).reset_index()
         
         
-        water_df_seperate_lu_wide.to_json(f'{SAVE_DIR}/water_4_volume_by_landuse.json',orient='records')
+        water_df_seperate_lu_wide.to_json(f'{SAVE_DIR}/water_4_net_yield_by_landuse.json',orient='records')
         
         
-        # Plot_5-5: Water use by Water_supply (ML)
+        # Plot_5-5: Water net yield by Water_supply (ML)
         water_df_seperate_irr = water_df_separate.groupby(['Year','Water_supply']).sum()[['Water Net Yield (ML)']].reset_index()
         
         water_df_seperate_irr_wide = water_df_seperate_irr\
@@ -1149,7 +1150,7 @@ def save_report_data(raw_data_dir:str):
                                         
         water_df_seperate_irr_wide.columns = ['name','data']
         water_df_seperate_irr_wide['type'] = 'column'
-        water_df_seperate_irr_wide.to_json(f'{SAVE_DIR}/water_5_volume_by_Water_supply.json',orient='records')
+        water_df_seperate_irr_wide.to_json(f'{SAVE_DIR}/water_5_net_yield_by_Water_supply.json',orient='records')
     
 
 

--- a/luto/tools/report/data_tools/template_html/pages/water_usage.html
+++ b/luto/tools/report/data_tools/template_html/pages/water_usage.html
@@ -40,20 +40,20 @@
     <div class="content">
         <h1>Water Use</h1>
 
-        <!-- Chart:water_3_volume_by_sector -->
-        <div class="fig" id="water_3_volume_by_sector"></div>
+        <!-- Chart:water_3_net_yield_by_sector -->
+        <div class="fig" id="water_3_net_yield_by_sector"></div>
 
-        <!-- Chart:water_4_volume_by_landuse -->
-        <div class="fig" id="water_4_volume_by_landuse"></div>
+        <!-- Chart:water_4_net_yield_by_landuse -->
+        <div class="fig" id="water_4_net_yield_by_landuse"></div>
 
-        <!-- Chart:water_5_volume_by_Water_supply -->
-        <div class="fig" id="water_5_volume_by_Water_supply"></div>
+        <!-- Chart:water_5_net_yield_by_Water_supply -->
+        <div class="fig" id="water_5_net_yield_by_Water_supply"></div>
 
         <!-- Chart:water_1_percent_to_limit -->
         <div class="fig" id="water_1_percent_to_limit"></div>
 
-        <!-- Chart:water_2_volume_to_limit -->
-        <div class="fig" id="water_2_volume_to_limit"></div>
+        <!-- Chart:water_2_yield_to_limit -->
+        <div class="fig" id="water_2_yield_to_limit"></div>
 
 
 

--- a/luto/tools/report/data_tools/template_html/pages/water_usage.html
+++ b/luto/tools/report/data_tools/template_html/pages/water_usage.html
@@ -49,8 +49,8 @@
         <!-- Chart:water_5_net_yield_by_Water_supply -->
         <div class="fig" id="water_5_net_yield_by_Water_supply"></div>
 
-        <!-- Chart:water_1_percent_to_limit -->
-        <div class="fig" id="water_1_percent_to_limit"></div>
+        <!-- Chart:water_1_percent_of_limit -->
+        <div class="fig" id="water_1_percent_of_limit"></div>
 
         <!-- Chart:water_2_yield_to_limit -->
         <div class="fig" id="water_2_yield_to_limit"></div>

--- a/luto/tools/report/data_tools/template_html/pages/water_usage.js
+++ b/luto/tools/report/data_tools/template_html/pages/water_usage.js
@@ -24,15 +24,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
 
 
-  // Chart:water_1_percent_to_limit
-  Highcharts.chart("water_1_percent_to_limit", {
+  // Chart:water_1_percent_of_limit
+  Highcharts.chart("water_1_percent_of_limit", {
     chart: {
       type: "spline",
       marginRight: 380,
     },
 
     title: {
-      text: "Water Use as Percentage to Avaliable Water Resources",
+      text: "Water Net Yield as Percentage of Lower Bound",
     },
 
     credits: {
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
 
     series: JSON.parse(
-      document.getElementById("water_1_percent_to_limit_csv").innerHTML
+      document.getElementById("water_1_percent_of_limit_csv").innerHTML
     ),
     xAxis: {
       tickPositions: year_ticks,
@@ -94,7 +94,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     yAxis: {
       title: {
-        text: "Water Use (ML)",
+        text: "Water Net Yield (ML)",
       },
     },
 
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     yAxis: {
       title: {
-        text: "Water Use (ML)",
+        text: "Water Net Yield (ML)",
       },
     },
 
@@ -197,7 +197,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     yAxis: {
       title: {
-        text: "Water Use (ML)",
+        text: "Water Net Yield (ML)",
       },
     },
 
@@ -259,7 +259,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
     yAxis: {
       title: {
-        text: "Water Use (ML)",
+        text: "Water Net Yield (ML)",
       },
     },
 

--- a/luto/tools/report/data_tools/template_html/pages/water_usage.js
+++ b/luto/tools/report/data_tools/template_html/pages/water_usage.js
@@ -71,15 +71,15 @@ document.addEventListener("DOMContentLoaded", function () {
     },
   });
 
-  // Chart:water_2_volume_to_limit
-  Highcharts.chart("water_2_volume_to_limit", {
+  // Chart:water_2_yield_to_limit
+  Highcharts.chart("water_2_yield_to_limit", {
     chart: {
       type: "spline",
       marginRight: 380,
     },
 
     title: {
-      text: "Water Use by Drainage Division/River Region",
+      text: "Water Net Yield by Drainage Division/River Region",
     },
 
     credits: {
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
 
     series: JSON.parse(
-      document.getElementById("water_2_volume_to_limit_csv").innerHTML
+      document.getElementById("water_2_yield_to_limit_csv").innerHTML
     ),
     xAxis: {
       tickPositions: year_ticks,
@@ -118,15 +118,15 @@ document.addEventListener("DOMContentLoaded", function () {
     },
   });
 
-  // Chart:water_3_volume_by_sector
-  Highcharts.chart("water_3_volume_by_sector", {
+  // Chart:water_3_net_yield_by_sector
+  Highcharts.chart("water_3_net_yield_by_sector", {
     chart: {
       type: "column",
       marginRight: 380,
     },
 
     title: {
-      text: "Water Use by Broad Land-use and Management Type",
+      text: "Water Net Yield by Broad Land-use and Management Type",
     },
 
     credits: {
@@ -134,7 +134,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
 
     series: JSON.parse(
-      document.getElementById("water_3_volume_by_sector_csv").innerHTML
+      document.getElementById("water_3_net_yield_by_sector_csv").innerHTML
     ),
     xAxis: {
       tickPositions: year_ticks,
@@ -174,15 +174,15 @@ document.addEventListener("DOMContentLoaded", function () {
     },
   });
 
-  // Chart:water_4_volume_by_landuse
-  Highcharts.chart("water_4_volume_by_landuse", {
+  // Chart:water_4_net_yield_by_landuse
+  Highcharts.chart("water_4_net_yield_by_landuse", {
     chart: {
       type: "column",
       marginRight: 380,
     },
 
     title: {
-      text: "Water Use by Land-use and Agricultural Commodity",
+      text: "Water Net Yield by Land-use and Agricultural Commodity",
     },
 
     credits: {
@@ -190,7 +190,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
 
     series: JSON.parse(
-      document.getElementById("water_4_volume_by_landuse_csv").innerHTML
+      document.getElementById("water_4_net_yield_by_landuse_csv").innerHTML
     ),
     xAxis: {
       tickPositions: year_ticks,
@@ -236,15 +236,15 @@ document.addEventListener("DOMContentLoaded", function () {
     },
   });
 
-  // Chart:water_5_volume_by_Water_supply
-  Highcharts.chart("water_5_volume_by_Water_supply", {
+  // Chart:water_5_net_yield_by_Water_supply
+  Highcharts.chart("water_5_net_yield_by_Water_supply", {
     chart: {
       type: "column",
       marginRight: 380,
     },
 
     title: {
-      text: "Water Use by Irrigation Type",
+      text: "Water Net Yield by Irrigation Type",
     },
 
     credits: {
@@ -252,7 +252,7 @@ document.addEventListener("DOMContentLoaded", function () {
     },
 
     series: JSON.parse(
-      document.getElementById("water_5_volume_by_Water_supply_csv").innerHTML
+      document.getElementById("water_5_net_yield_by_Water_supply_csv").innerHTML
     ),
     xAxis: {
       tickPositions: year_ticks,

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -849,7 +849,7 @@ def write_water(data: Data, yr_cal, path):
                                 , 'PROPORTION_ALL_%'] )
 
     # Get 2010 water use limits used as constraints in model
-    w_net_yield_limits = ag_water.get_water_net_yield_limits(data)
+    w_net_yield_limits = ag_water.get_water_net_yield_limits(data, yr_cal)
 
     # Set up data for river regions or drainage divisions
     if settings.WATER_REGION_DEF == 'Drainage Division':
@@ -865,7 +865,10 @@ def write_water(data: Data, yr_cal, path):
         region_dict = data.RIVREG_DICT
 
     else:
-        print('Incorrect option for WATER_REGION_DEF in settings')
+        raise ValueError(
+            f"Incorrect option for WATER_REGION_DEF in settings: {settings.WATER_REGION_DEF} "
+            f"(must be either 'Drainage Division' or 'River Region')."
+        )
 
     # Loop through specified water regions
     df_water_seperate_dfs = []
@@ -960,8 +963,6 @@ def write_water(data: Data, yr_cal, path):
                     , abs_diff
                     , prop_diff
                     , prop_all)
-
-    breakpoint()
 
     # Write to CSV with 2 DP
     df = df.drop(columns=['REGION_ID']).set_index('REGION_NAME').stack().reset_index()

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -837,7 +837,7 @@ def write_water(data: Data, yr_cal, path):
     # Get water use for year in mrj format
     ag_w_mrj = ag_water.get_wreq_matrices(data, yr_idx)
     non_ag_w_rk = non_ag_water.get_w_net_yield_matrix(data, ag_w_mrj, data.lumaps[yr_cal])
-    ag_man_w_mrj = ag_water.get_agricultural_management_water_matrices(data, ag_w_mrj, yr_idx)
+    ag_man_w_mrj = ag_water.get_agricultural_management_water_matrices(data, yr_idx)
 
     # Prepare a data frame.
     df = pd.DataFrame( columns=[ 'REGION_ID'

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -835,7 +835,7 @@ def write_water(data: Data, yr_cal, path):
     yr_idx = yr_cal - data.YR_CAL_BASE
 
     # Get water use for year in mrj format
-    ag_w_mrj = ag_water.get_wreq_matrices(data, yr_idx)
+    ag_w_mrj = ag_water.get_water_net_yield_matrices(data, yr_idx)
     non_ag_w_rk = non_ag_water.get_w_net_yield_matrix(data, ag_w_mrj, data.lumaps[yr_cal])
     ag_man_w_mrj = ag_water.get_agricultural_management_water_matrices(data, yr_idx)
 
@@ -848,7 +848,7 @@ def write_water(data: Data, yr_cal, path):
                                 , 'PROPORTION_LIMIT_%'
                                 , 'PROPORTION_ALL_%'] )
 
-    # Get 2010 water use limits used as constraints in model
+    # Get water use limits used as constraints in model
     w_net_yield_limits = ag_water.get_water_net_yield_limits(data, yr_cal)
 
     # Set up data for river regions or drainage divisions
@@ -950,11 +950,12 @@ def write_water(data: Data, yr_cal, path):
         baseline_net_yield_all =  w_net_yield_limits[region][1]                    # Baseline water net yield
         net_yield_lb = w_net_yield_limits[region][2]                               # Water net yield lower bound
         w_net_yield_reg = df_region['Water Net Yield (ML)'].sum() + reg_cc_impact  # Solved water net yield of the region plus climate change impacts
+
         # Calculate absolute and proportional difference between water use target and actual water use
         abs_diff = w_net_yield_reg - net_yield_lb
-        prop_diff = (w_net_yield_reg / net_yield_lb) * 100 # if net_yield_lb > 0 else np.nan
-        prop_all = (w_net_yield_reg / baseline_net_yield_all) * 100 # if baseline_net_yield_all > 0 else np.nan
-            # TODO ^ figure out if the above if statements should be included
+        prop_diff = (w_net_yield_reg / net_yield_lb) * 100
+        prop_all = (w_net_yield_reg / baseline_net_yield_all) * 100
+
         # Add to dataframe
         df.loc[i] = ( region
                     , region_dict[region]

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -836,7 +836,7 @@ def write_water(data: Data, yr_cal, path):
 
     # Get water use for year in mrj format
     ag_w_mrj = ag_water.get_wreq_matrices(data, yr_idx)
-    non_ag_w_rk = non_ag_water.get_wreq_matrix(data, ag_w_mrj, data.lumaps[yr_cal])
+    non_ag_w_rk = non_ag_water.get_w_net_yield_matrix(data, ag_w_mrj, data.lumaps[yr_cal])
     ag_man_w_mrj = ag_water.get_agricultural_management_water_matrices(data, ag_w_mrj, yr_idx)
 
     # Prepare a data frame.


### PR DESCRIPTION
Revamps the water constraints in LUTO in the following ways:
- Water limits are now limits on net water yield, given by water yield minus water usage.
- Adds GHG effects of water usage from outside the LUTO study area on water regions
- Adds the WATER_YIELD_TARGETS setting allowing for water limits to be slowly met over time rather than from 2011 onwards.