### PR TITLE
Remove parallelization for the calculation of biodiversity contribution

### DIFF
--- a/luto/data.py
+++ b/luto/data.py
@@ -998,6 +998,9 @@ class Data:
         for yr in range(2010, 2101):
             self.BIODIV_GBF_TARGET_2[yr] = biodiv_value_current_total + (biodiv_value_degraded_total * biodiv_GBF_target_2_proportions_2010_2100[yr]) 
         
+        
+       
+        
 
         ###############################################################
         # BECCS data.

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -96,7 +96,7 @@ AMORTISATION_PERIOD = 30 # years
 # ---------------------------------------------------------------------------- #
 
 # Optionally coarse-grain spatial domain (faster runs useful for testing). E.g. RESFACTOR 5 selects the middle cell in every 9 x 9 cell block
-RESFACTOR = 10        # set to 1 to run at full spatial resolution, > 1 to run at reduced resolution. 
+RESFACTOR = 5        # set to 1 to run at full spatial resolution, > 1 to run at reduced resolution. 
 
 # How does the model run over time 
 # MODE = 'snapshot'   # Runs for target year only

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -99,8 +99,8 @@ AMORTISATION_PERIOD = 30 # years
 RESFACTOR = 10        # set to 1 to run at full spatial resolution, > 1 to run at reduced resolution. 
 
 # How does the model run over time 
-MODE = 'snapshot'   # Runs for target year only
-# MODE = 'timeseries'   # Runs each year from base year to target year
+# MODE = 'snapshot'   # Runs for target year only
+MODE = 'timeseries'   # Runs each year from base year to target year
 
 # Define the objective function
 OBJECTIVE = 'maxprofit'   # maximise profit (revenue - costs)  **** Requires soft demand constraints otherwise agriculture over-produces

--- a/luto/tools/report/create_html.py
+++ b/luto/tools/report/create_html.py
@@ -62,7 +62,7 @@ def data2html(raw_data_dir):
         html_path = row['path']
         data_pathes  = row['data_path']
         # Add data to html
-        add_data_2_html(html_path,data_pathes)
+        add_data_2_html(html_path, data_pathes)
         
 
     

--- a/luto/tools/report/create_report_data.py
+++ b/luto/tools/report/create_report_data.py
@@ -1158,14 +1158,15 @@ def save_report_data(raw_data_dir:str):
     #########################################################
     #                   6) Biodiversity                     #
     #########################################################
-
+    
+    # ---------------- Biodiversity priority score  ----------------
     # get biodiversity dataframe
     bio_paths = files.query('category == "biodiversity" and year_types == "single_year" and base_name == "biodiversity_separate"').reset_index(drop=True)
     bio_df = pd.concat([pd.read_csv(path) for path in bio_paths['path']])
     bio_df['Biodiversity score (million)'] = bio_df['Biodiversity score'] / 1e6
     bio_df = bio_df.replace(RENAME_AM_NON_AG)
 
-    # Filter out landuse that are reated to biodiversity
+    # Filter out landuse that are related to biodiversity
     bio_lucc = LU_NATURAL + NON_AG_LANDUSE
 
 
@@ -1226,6 +1227,74 @@ def save_report_data(raw_data_dir:str):
     natural_land_area.columns = ['name','data']
     natural_land_area['type'] = 'column'
     natural_land_area.to_json(f'{SAVE_DIR}/biodiversity_4_natural_land_area.json',orient='records')
+    
+    
+    # ---------------- Biodiversity contribution score  ----------------
+    bio_paths = files.query('category == "biodiversity" and year_types == "single_year" and base_name == "biodiversity_contribution"').reset_index(drop=True)
+    bio_df = pd.concat([pd.read_csv(path) for path in bio_paths['path']])
+    bio_df = bio_df.replace(RENAME_AM_NON_AG)                   # Rename the landuse
+    
+    bio_df['lm'] = bio_df['lm'].replace({
+        'dry':'Dryland', 
+        'irr':'Irrigated',
+        np.nan: 'Dryland'})    # Replace `nan` to 'Dryland'
+    
+    bio_df['lu_type'] = bio_df['lu_type'].replace({
+        'ag': 'Agricultural Landuse',
+        'non_ag': 'Non-Agricultural Landuse',
+        'am': 'Agricultural Management'})   
+    
+    bio_df['group'] = bio_df['group'].replace({
+        'all_species': 'All species', 
+        'amphibians': 'Amphibians',
+        'birds': 'Birds',
+        'mammals': 'Mammals',
+        'plants': 'Plants',
+        'reptiles': 'Reptiles'})
+ 
+    
+    # Plot_6-5: Biodiversity contribution score by group
+    bio_df_species_group = bio_df.groupby(['group','year']).sum(numeric_only=True).reset_index()
+    
+    bio_df_species_group = bio_df_species_group\
+        .groupby('group')[['year','contribution_%']]\
+        .apply(lambda x:list(map(list,zip(x['year'],x['contribution_%']))))\
+        .reset_index()
+        
+    bio_df_species_group.columns = ['name','data']
+    bio_df_species_group['type'] = 'spline'
+    bio_df_species_group.to_json(f'{SAVE_DIR}/biodiversity_5_contribution_score_by_group.json',orient='records')
+
+
+
+
+    # Plot_6-6: Biodiversity contribution score by landuse broader type
+    bio_df_landuse_type_broad = bio_df.query('group == "All species"').groupby(['lu_type','year']).sum(numeric_only=True).reset_index()
+    bio_df_landuse_type_broad = bio_df_landuse_type_broad\
+        .groupby('lu_type')[['year','contribution_%']]\
+        .apply(lambda x:list(map(list,zip(x['year'],x['contribution_%']))))\
+        .reset_index()
+        
+    bio_df_landuse_type_broad.columns = ['name','data']
+    bio_df_landuse_type_broad['type'] = 'column'
+    bio_df_landuse_type_broad.to_json(f'{SAVE_DIR}/biodiversity_6_contribution_score_by_landuse_type_broad.json',orient='records')
+    
+    
+    # Plot_6-7: Biodiversity contribution score by specific landuse type
+    bio_df_landuse_type_specific = bio_df.query('group == "All species"').groupby(['lu','year']).sum(numeric_only=True).reset_index()
+    bio_df_landuse_type_specific = bio_df_landuse_type_specific\
+        .groupby('lu')[['year','contribution_%']]\
+        .apply(lambda x:list(map(list,zip(x['year'],x['contribution_%']))))\
+        .reset_index()
+        
+    bio_df_landuse_type_specific.columns = ['name','data']
+    bio_df_landuse_type_specific['type'] = 'column'
+    bio_df_landuse_type_specific['sort_index'] = bio_df_landuse_type_specific['name'].apply(lambda x: LANDUSE_ALL.index(x))
+    bio_df_landuse_type_specific = bio_df_landuse_type_specific.sort_values(['sort_index']).drop('sort_index',axis=1)
+    bio_df_landuse_type_specific.to_json(f'{SAVE_DIR}/biodiversity_7_contribution_score_by_landuse_type_specific.json',orient='records')
+    
+    
+
     
     
     #########################################################

--- a/luto/tools/report/data_tools/template_html/pages/biodiversity.html
+++ b/luto/tools/report/data_tools/template_html/pages/biodiversity.html
@@ -54,6 +54,15 @@
         <!-- Chart:biodiversity_4_natural_land_area -->
         <div class="fig" id="biodiversity_4_natural_land_area"></div>
 
+        <!-- Chart:biodiversity_5_contribution_score_by_group -->
+        <div class="fig" id="biodiversity_5_contribution_score_by_group"></div>
+
+        <!-- Chart:biodiversity_6_contribution_score_by_landuse_type_broad -->
+        <div class="fig" id="biodiversity_6_contribution_score_by_landuse_type_broad"></div>
+
+        <!-- Chart:biodiversity_7_contribution_score_by_landuse_type_specific -->
+        <div class="fig" id="biodiversity_7_contribution_score_by_landuse_type_specific"></div>
+
 
     </div>
 

--- a/luto/tools/report/data_tools/template_html/pages/biodiversity.js
+++ b/luto/tools/report/data_tools/template_html/pages/biodiversity.js
@@ -161,6 +161,130 @@ document.addEventListener("DOMContentLoaded", function () {
         },
     });
 
+    // biodiversity_5_contribution_score_by_group
+    Highcharts.chart("biodiversity_5_contribution_score_by_group", {
+        chart: {
+            type: "column",
+            marginRight: 380,
+        },
+        title: {
+            text: "Biodiversity Contribution by Group",
+        },
+        series: JSON.parse(
+            document.getElementById("biodiversity_5_contribution_score_by_group_csv").innerHTML
+        ),
+        xAxis: {
+            tickPositions: year_ticks,
+        },
+        yAxis: {
+            title: {
+                text: "Contribution Score (%)",
+            },
+        },
+        tooltip: {
+            formatter: function () {
+                return `<b>Year:</b> ${this.x}<br><b>${this.series.name
+                    }:</b>${this.y.toFixed(2)}<br/>`;
+            },
+        },
+        legend: {
+            align: "right",
+            verticalalign: "left",
+            layout: "vertical",
+            x: 0,
+            verticalAlign: "middle",
+        },
+        credits: {
+            enabled: false,
+        },
+    });
+
+    // biodiversity_6_contribution_score_by_landuse_type_broad
+    Highcharts.chart("biodiversity_6_contribution_score_by_landuse_type_broad", {
+        chart: {
+            type: "column",
+            marginRight: 380,
+        },
+        title: {
+            text: "Biodiversity Contribution by Land-use Type (Broad)",
+        },
+        series: JSON.parse(
+            document.getElementById("biodiversity_6_contribution_score_by_landuse_type_broad_csv").innerHTML
+        ),
+        xAxis: {
+            tickPositions: year_ticks,
+        },
+        yAxis: {
+            title: {
+                text: "Contribution Score (%)",
+            },
+        },
+        plotOptions: {
+            column: {
+                stacking: "normal",
+            },
+        },
+        tooltip: {
+            formatter: function () {
+                return `<b>Year:</b> ${this.x}<br><b>${this.series.name
+                    }:</b>${this.y.toFixed(2)}<br/>`;
+            },
+        },
+        legend: {
+            align: "right",
+            verticalalign: "left",
+            layout: "vertical",
+            x: 0,
+            verticalAlign: "middle",
+        },
+        credits: {
+            enabled: false,
+        },
+    });
+
+
+    // biodiversity_7_contribution_score_by_landuse_type_specific
+    Highcharts.chart("biodiversity_7_contribution_score_by_landuse_type_specific", {
+        chart: {
+            type: "column",
+            marginRight: 380,
+        },
+        title: {
+            text: "Biodiversity Contribution by Land-use Type (Specific)",
+        },
+        series: JSON.parse(
+            document.getElementById("biodiversity_7_contribution_score_by_landuse_type_specific_csv").innerHTML
+        ),
+        xAxis: {
+            tickPositions: year_ticks,
+        },
+        yAxis: {
+            title: {
+                text: "Contribution Score (%)",
+            },
+        },
+        plotOptions: {
+            column: {
+                stacking: "normal",
+            },
+        },
+        tooltip: {
+            formatter: function () {
+                return `<b>Year:</b> ${this.x}<br><b>${this.series.name
+                    }:</b>${this.y.toFixed(2)}<br/>`;
+            },
+        },
+        legend: {
+            align: "right",
+            verticalalign: "left",
+            layout: "vertical",
+            x: 0,
+            verticalAlign: "middle",
+        },
+        credits: {
+            enabled: false,
+        },
+    });
 
 });
 

--- a/luto/tools/report/data_tools/template_html/pages/biodiversity.js
+++ b/luto/tools/report/data_tools/template_html/pages/biodiversity.js
@@ -191,7 +191,7 @@ document.addEventListener("DOMContentLoaded", function () {
             align: "right",
             verticalalign: "left",
             layout: "vertical",
-            x: 0,
+            x: -250,
             verticalAlign: "middle",
         },
         credits: {
@@ -234,7 +234,7 @@ document.addEventListener("DOMContentLoaded", function () {
             align: "right",
             verticalalign: "left",
             layout: "vertical",
-            x: 0,
+            x: -150,
             verticalAlign: "middle",
         },
         credits: {
@@ -275,12 +275,17 @@ document.addEventListener("DOMContentLoaded", function () {
             },
         },
         legend: {
+            itemStyle: {
+              fontSize: "11px",
+            },
             align: "right",
-            verticalalign: "left",
             layout: "vertical",
-            x: 0,
+            x: -30,
+            y: -10,
             verticalAlign: "middle",
-        },
+            itemMarginTop: 0,
+            itemMarginBottom: 1,
+          },
         credits: {
             enabled: false,
         },

--- a/luto/tools/spatializers.py
+++ b/luto/tools/spatializers.py
@@ -95,21 +95,26 @@ def upsample_array(data, map_:np.ndarray, factor:int) -> np.ndarray:
     """
     dense_2D_shape = data.NLUM_MASK.shape
     dense_2D_map = np.repeat(np.repeat(map_, factor, axis=0), factor, axis=1)       # Simply repeate each cell by `factor` times at every row/col direction  
+    
+    
+    # Adjust the dense_2D_map size if it exceeds the original shape
+    if dense_2D_map.shape[0] > dense_2D_shape[0] or dense_2D_map.shape[1] > dense_2D_shape[1]:
+        dense_2D_map = dense_2D_map[:dense_2D_shape[0], :dense_2D_shape[1]]
+    
+    # Pad the array if necessary
+    if dense_2D_map.shape[0] < dense_2D_shape[0] or dense_2D_map.shape[1] < dense_2D_shape[1]:
+        pad_height = dense_2D_shape[0] - dense_2D_map.shape[0]
+        pad_width = dense_2D_shape[1] - dense_2D_map.shape[1]
+        dense_2D_map = np.pad(
+            dense_2D_map, 
+            pad_width=((0, pad_height), (0, pad_width)), 
+            mode='edge'
+        )
 
-    # Make sure it has the same shape as the original full-res 2D map
-    dense_2D_map = dense_2D_map[0:dense_2D_shape[0], 0:dense_2D_shape[1]] 
-    
-    # Pad the array
-    pad_height = dense_2D_shape[0] - dense_2D_map.shape[0]
-    pad_width = dense_2D_shape[1] - dense_2D_map.shape[1]
-    dense_2D_map = np.pad(
-        dense_2D_map, 
-        pad_width=((0, pad_height), (0, pad_width)), 
-        mode='edge')        
-    
+    # Apply the masks
     filler_mask = data.LUMAP_2D != data.MASK_LU_CODE
-    dense_2D_map = np.where(filler_mask, dense_2D_map, data.MASK_LU_CODE)           # Apply the LU mask to the dense 2D map.
-    dense_2D_map = np.where(data.NLUM_MASK, dense_2D_map, data.NODATA)              # Apply the NLUM mask to the dense 2D map.
+    dense_2D_map = np.where(filler_mask, dense_2D_map, data.MASK_LU_CODE)
+    dense_2D_map = np.where(data.NLUM_MASK, dense_2D_map, data.NODATA)
     return dense_2D_map
 
 

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -1148,7 +1148,7 @@ def write_biodiversity_contribution(data: Data, yr_cal, path):
     ag_dvar = ag_to_xr(data, yr_cal)
     am_dvar = am_to_xr(data, yr_cal)
     non_ag_dvar = non_ag_to_xr(data, yr_cal)  
-    
+        
     # Reproject and match dvars (1D vector) to the bio map (2D, ~5km). NOTE: The dvars are sparsed array at ~5km resolution.
     ag_dvar = ag_dvar_to_bio_map(data, ag_dvar, settings.RESFACTOR).chunk('auto').compute()
     am_dvar = am_dvar_to_bio_map(data, am_dvar, settings.RESFACTOR).chunk('auto').compute()

--- a/luto/tools/xarray_tools.py
+++ b/luto/tools/xarray_tools.py
@@ -196,7 +196,7 @@ def match_lumap_biomap(
 
 
 
-def ag_dvar_to_bio_map(data, ag_dvar, res_factor, workers=5):
+def ag_dvar_to_bio_map(data, ag_dvar, res_factor):
     """
     Reprojects and matches agricultural land cover variables to biodiversity maps.
 
@@ -217,10 +217,9 @@ def ag_dvar_to_bio_map(data, ag_dvar, res_factor, workers=5):
         map_ = map_.expand_dims({'lm': [lm], 'lu': [lu]})
         return map_
     
-    tasks = [delayed(reproject_match_dvar)(ag_dvar, lm, lu, res_factor) 
+    out_arr = [reproject_match_dvar(ag_dvar, lm, lu, res_factor) 
              for lm,lu in product(ag_dvar['lm'].values, ag_dvar['lu'].values)]
-    para_obj = Parallel(n_jobs=workers, return_as='generator')
-    out_arr = xr.combine_by_coords([i for i in para_obj(tasks)])
+    out_arr = xr.combine_by_coords(out_arr)
     
     # Convert to sparse array to save memory
     out_arr.values = sparse.COO.from_numpy(out_arr.values)
@@ -228,7 +227,7 @@ def ag_dvar_to_bio_map(data, ag_dvar, res_factor, workers=5):
     return out_arr
 
 
-def am_dvar_to_bio_map(data, am_dvar, res_factor, workers=5):
+def am_dvar_to_bio_map(data, am_dvar, res_factor):
     """
     Reprojects and matches agricultural land cover variables to biodiversity maps.
 
@@ -249,10 +248,9 @@ def am_dvar_to_bio_map(data, am_dvar, res_factor, workers=5):
         map_ = map_.expand_dims({'am':[am], 'lm': [lm], 'lu': [lu]})
         return map_
 
-    tasks = [delayed(reproject_match_dvar)(am_dvar, am, lm, lu, res_factor) 
+    out_arr = [reproject_match_dvar(am_dvar, am, lm, lu, res_factor) 
             for am,lm,lu in product(am_dvar['am'].values, am_dvar['lm'].values, am_dvar['lu'].values)]
-    para_obj = Parallel(n_jobs=workers, return_as='generator')
-    out_arr = xr.combine_by_coords([i for i in para_obj(tasks)])
+    out_arr = xr.combine_by_coords(out_arr)
     
     # Convert to sparse array to save memory
     out_arr.values = sparse.COO.from_numpy(out_arr.values)
@@ -261,7 +259,7 @@ def am_dvar_to_bio_map(data, am_dvar, res_factor, workers=5):
 
 
 
-def non_ag_dvar_to_bio_map(data, non_ag_dvar, res_factor, workers=5):
+def non_ag_dvar_to_bio_map(data, non_ag_dvar, res_factor):
     """
     Reprojects and matches agricultural land cover variables to biodiversity maps.
 
@@ -282,10 +280,9 @@ def non_ag_dvar_to_bio_map(data, non_ag_dvar, res_factor, workers=5):
         map_ = map_.expand_dims({'lu': [lu]})
         return map_
 
-    tasks = [delayed(reproject_match_dvar)(non_ag_dvar, lu, res_factor) 
+    out_arr = [reproject_match_dvar(non_ag_dvar, lu, res_factor) 
             for lu in non_ag_dvar['lu'].values]
-    para_obj = Parallel(n_jobs=workers, return_as='generator')
-    out_arr = xr.combine_by_coords([i for i in para_obj(tasks)])
+    out_arr = xr.combine_by_coords(out_arr)
     
     # Convert to sparse array to save memory
     out_arr.values = sparse.COO.from_numpy(out_arr.values)


### PR DESCRIPTION
The parallelization of biodiversity calculation is constantly causing errors. So I am now using native for-loop for the calculation.

Overhead cost incurs!!!
  - It needs ~4min to compute 'biodiversity contribution' each year in the reporting process.