### PR TITLE
Add setting to relax water constraints to avoid infeasibility

### DIFF
--- a/luto/data.py
+++ b/luto/data.py
@@ -735,8 +735,7 @@ class Data:
 
         # Initialise container for water usage limits to avoid re-calculating the figures
         # during timeseries solves.
-        self.STANDARD_WATER_LIMITS_BY_YEAR = None
-        self.WATER_LIMITS_BY_YEAR_UNDER_CLIMATE_CHANGE = None
+        self.WATER_LIMITS_BY_YEAR = None
 
         # Water requirements by land use -- LVSTK.
         wreq_lvstk_dry = pd.DataFrame()

--- a/luto/economics/agricultural/water.py
+++ b/luto/economics/agricultural/water.py
@@ -469,23 +469,46 @@ def _get_historical_water_usage_by_regions(data: Data) -> dict[int, tuple[str, f
     return net_baseline_reg_water_yield
 
 
-def _get_water_net_yield_limit_under_climate_change(
+def get_water_net_yield_limits(
     data: Data, yr_cal: int,
-) -> tuple[str, float, float, np.ndarray]:
+) -> dict[int, tuple[str, float, float, np.ndarray]]:
     """
-    Calculate water net yield limit as previously done, however use land use/mgt decision variables
-    for year t-1 and the water yield layers for year t
+    Return water net yield limits for regions (River Regions or Drainage Divisions as specified in luto.settings.py).
+    
+    Limits are year-specific, beginning at the 2010 net water yields and decreasing to the defined limits
+    in the year given by settings.WATER_LIMITS_TARGET_YEAR.
 
-    TODO: not sure if this is required or not, just leave here for now incase
+    Parameters:
+    - data: The data object containing the necessary input data.
+
+    Returns:
+    water_net_yield_limits: A dictionary of tuples containing the water use limits for each region\n
+      region index:(
+      - region name 
+      - histircal water yield
+      - lowest water yield allowed 
+      - indices of cells in the region
+      )
+
+    Raises:
+    - None
+
     """
+    if any([not data.YR_CAL_BASE <= yr <= 2100 for yr in settings.WATER_YIELD_TARGETS]):
+        raise ValueError(
+            f"Setting WATER_YIELD_TARGETS must be defined for years between " 
+            f"{data.YR_CAL_BASE} and 2100."
+        )
 
-    hist_yield = 0
-    limit = 0
-
-    return (hist_yield, limit)
-
-
-def _get_standard_water_net_yield_limits(data: Data) -> None:
+    latest_target_year = max(settings.WATER_YIELD_TARGETS)
+    if data.WATER_LIMITS_BY_YEAR: 
+        return (
+            data.WATER_LIMITS_BY_YEAR[latest_target_year] 
+            if yr_cal >= latest_target_year
+            else data.WATER_LIMITS_BY_YEAR[yr_cal]
+        )
+    
+    # Limits do not yet exist and must be calculated
     historical_yields_dict = _get_historical_water_usage_by_regions(data)
     base_yr_net_yield_by_reg = calc_water_net_yield_by_region_in_year(data, data.YR_CAL_BASE)
 
@@ -522,48 +545,14 @@ def _get_standard_water_net_yield_limits(data: Data) -> None:
             for yr, limit in zip(calc_years, yrs_targets):
                 limits_by_region_year[yr][region] = (name, hist_yield, limit, ind)
     
-    # Save to data object
-    data.STANDARD_WATER_LIMITS_BY_YEAR = dict(limits_by_region_year)
+    # Save to data object to avoid re-calculating in the future.
+    data.WATER_LIMITS_BY_YEAR = dict(limits_by_region_year)
 
-
-def get_water_net_yield_limits(
-    data: Data, yr_cal: int,
-) -> dict[int, tuple[str, float, float, np.ndarray]]:
-    """
-    Return water net yield limits for regions (River Regions or Drainage Divisions as specified in luto.settings.py).
-    
-    Limits are year-specific, beginning at the 2010 net water yields and decreasing to the defined limits
-    in the year given by settings.WATER_LIMITS_TARGET_YEAR.
-
-    Parameters:
-    - data: The data object containing the necessary input data.
-
-    Returns:
-    water_net_yield_limits: A dictionary of tuples containing the water use limits for each region\n
-      region index:(
-      - region name 
-      - histircal water yield
-      - lowest water yield allowed 
-      - indices of cells in the region
-      )
-
-    Raises:
-    - None
-
-    """
-    if any([not data.YR_CAL_BASE <= yr <= 2100 for yr in settings.WATER_YIELD_TARGETS]):
-        raise ValueError(
-            f"Setting WATER_YIELD_TARGETS must be defined for years between " 
-            f"{data.YR_CAL_BASE} and 2100."
-        )
-
-    latest_target_year = max(settings.WATER_YIELD_TARGETS)
-
-    if not data.STANDARD_WATER_LIMITS_BY_YEAR:
-        data.STANDARD_WATER_LIMITS_BY_YEAR = _get_standard_water_net_yield_limits(data)
-    limit_year = min(yr_cal, latest_target_year)
-
-    return data.STANDARD_WATER_LIMITS_BY_YEAR[limit_year][0]
+    return (
+        data.WATER_LIMITS_BY_YEAR[latest_target_year] if yr_cal >= latest_target_year
+        else data.WATER_LIMITS_BY_YEAR[yr_cal]
+    )
+ 
 
 
 """

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -122,7 +122,7 @@ PENALTY = 1e5
 WRITE_OUTPUT_GEOTIFFS = True    # Write GeoTiffs to output directory: True or False
 WRITE_FULL_RES_MAPS = False     # Write GeoTiffs at full or resfactored resolution: True or False
 PARALLEL_WRITE = True           # If to use parallel processing to write GeoTiffs: True or False
-WRITE_THREADS = 8              # The Threads to use for map making, only work with PARALLEL_WRITE = True
+WRITE_THREADS = 50              # The Threads to use for map making, only work with PARALLEL_WRITE = True
 
 # ---------------------------------------------------------------------------- #
 # Gurobi parameters
@@ -152,7 +152,7 @@ NUMERIC_FOCUS = 0   # Controls the degree to which the code attempts to detect a
 BARHOMOGENOUS = 1  # Useful for recognizing infeasibility or unboundedness. At the default setting (-1), it is only used when barrier solves a node relaxation for a MIP model. 0 = off, 1 = on. It is a bit slower than the default algorithm (3x slower in testing).
 
 # Number of threads to use in parallel algorithms (e.g., barrier)
-THREADS = 8
+THREADS = 50
 
 
 # ---------------------------------------------------------------------------- #

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -335,6 +335,8 @@ SOC_AMORTISATION = 15
 
 # Water use yield and parameters *******************************
 WATER_LIMITS = 'on'     # 'on' or 'off'. 'off' will turn off water net yield limit constraints in the solver.
+
+RELAXED_WATER_LIMITS_FOR_INFEASIBILITY = 'on'
     
             
 

--- a/luto/simulation.py
+++ b/luto/simulation.py
@@ -64,12 +64,6 @@ def solve_timeseries(data: Data, steps: int, base: int, target: int):
             old_non_ag_x_rk = luto_solver._input_data.non_ag_x_rk.copy()
             old_non_ag_lb_rk = luto_solver._input_data.non_ag_lb_rk.copy()
 
-            luto_solver.prev_X_ag_dry_vars_jr = luto_solver.X_ag_dry_vars_jr.copy()
-            luto_solver.prev_X_ag_irr_vars_jr = luto_solver.X_ag_irr_vars_jr.copy()
-            luto_solver.prev_X_ag_man_dry_vars_jr = luto_solver.X_non_ag_vars_kr.copy()
-            luto_solver.prev_X_ag_man_irr_vars_jr = luto_solver.X_ag_man_dry_vars_jr.copy()
-            luto_solver.prev_X_non_ag_vars_kr = luto_solver.X_ag_man_irr_vars_jr.copy()
-
             luto_solver.update_formulation(
                 input_data=input_data,
                 d_c=d_c,

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -75,6 +75,10 @@ class SolverInputData:
     desc2aglu: dict                 # Map of agricultural land use descriptions to codes.
     resmult: float                  # Resolution factor multiplier from data.RESMULT
 
+    base_year_ag_sol: np.ndarray = None                 # Base year's agricultural variables solution.
+    base_year_non_ag_sol: np.ndarray = None             # Base year's non-agricultural variables solution.
+    base_year_ag_man_sol: dict[str, np.ndarray] = None  # Base year's agricultural management variables solution.
+
     @property
     def n_ag_lms(self):
         # Number of agricultural landmans
@@ -358,7 +362,7 @@ def get_limits(
     # Limits is a dictionary with heterogeneous value sets.
     limits = {}
 
-    limits['water'] = ag_water.get_water_net_yield_limits(data, yr_cal)
+    limits['water'] = ag_water.get_water_net_yield_limit_values(data, yr_cal)
     
     if settings.GHG_EMISSIONS_LIMITS == 'on':
         limits['ghg'] = ag_ghg.get_ghg_limits(data, yr_cal)
@@ -429,4 +433,7 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
         limits=get_limits(data, target_year),
         desc2aglu=data.DESC2AGLU,
         resmult=data.RESMULT,
+        base_year_ag_sol=data.ag_dvars.get(base_year),
+        base_year_non_ag_sol=data.non_ag_dvars.get(base_year),
+        base_year_ag_man_sol=data.ag_man_dvars.get(base_year),
     )

--- a/luto/solvers/solver.py
+++ b/luto/solvers/solver.py
@@ -18,8 +18,6 @@
 Provides minimalist Solver class and pure helper functions.
 """
 
-from copy import deepcopy
-
 import numpy as np
 import gurobipy as gp
 import luto.settings as settings
@@ -83,13 +81,6 @@ class LutoSolver:
         self.X_ag_man_dry_vars_jr = None
         self.X_ag_man_irr_vars_jr = None
         self.V = None
-
-        # Initialise previous variable stores (only relevant for time series runs)
-        self.prev_X_ag_dry_vars_jr: np.ndarray = None
-        self.prev_X_ag_irr_vars_jr: np.ndarray = None
-        self.prev_X_ag_man_dry_vars_jr: dict[str, np.ndarray] = None
-        self.prev_X_ag_man_irr_vars_jr: dict[str, np.ndarray] = None
-        self.prev_X_non_ag_vars_kr: np.ndarray = None
 
         # Initialise constraint lookups
         self.cell_usage_constraint_r = {}
@@ -554,23 +545,19 @@ class LutoSolver:
         """
         if settings.WATER_LIMITS != "on":
             return
-        min_var = lambda var, prev_var: var if prev_var.x > 1e-3 else prev_var.x
-
+        
         print(f'  ...water net yield constraints by {settings.WATER_REGION_DEF}...')
 
         # Ensure water use remains below limit for each region
         for region, (reg_name, _, w_net_yield_limit, ind) in self._input_data.limits["water"].items():
-
             reg_ccimpact = self._input_data.w_ccimpact[region]
 
             ag_contr = gp.quicksum(
                 gp.quicksum(
-                    self._input_data.ag_w_mrj[0, ind, j] 
-                    * min_var(self.X_ag_dry_vars_jr[j, ind], self.prev_X_ag_dry_vars_jr[j, ind])
+                    self._input_data.ag_w_mrj[0, ind, j] * self.X_ag_dry_vars_jr[j, ind]
                 )  # Dryland agriculture contribution
                 + gp.quicksum(
-                    self._input_data.ag_w_mrj[1, ind, j] 
-                    * min_var(self.X_ag_irr_vars_jr[j, ind], self.prev_X_ag_irr_vars_jr[j, ind])
+                    self._input_data.ag_w_mrj[1, ind, j] * self.X_ag_irr_vars_jr[j, ind]
                 )  # Irrigated agriculture contribution
                 for j in range(self._input_data.n_ag_lus)
             )
@@ -578,11 +565,11 @@ class LutoSolver:
             ag_man_contr = gp.quicksum(
                 gp.quicksum(
                     self._input_data.ag_man_w_mrj[am][0, ind, j_idx]
-                    * min_var(self.X_ag_man_dry_vars_jr[am][j_idx, ind], self.prev_X_ag_man_dry_vars_jr[am][j_idx, ind])
+                    * self.X_ag_man_dry_vars_jr[am][j_idx, ind]
                 )  # Dryland alt. ag. management contributions
                 + gp.quicksum(
                     self._input_data.ag_man_w_mrj[am][1, ind, j_idx]
-                    * min_var(self.X_ag_man_irr_vars_jr[am][j_idx, ind], self.prev_X_ag_man_irr_vars_jr[am][j_idx, ind])
+                    * self.X_ag_man_irr_vars_jr[am][j_idx, ind]
                 )  # Irrigated alt. ag. management contributions
                 for am, am_j_list in self._input_data.am2j.items()
                 for j_idx in range(len(am_j_list))
@@ -590,8 +577,7 @@ class LutoSolver:
 
             non_ag_contr = gp.quicksum(
                 gp.quicksum(
-                    self._input_data.non_ag_w_rk[ind, k] 
-                    * min_var(self.X_non_ag_vars_kr[k, ind], self.prev_X_non_ag_vars_kr[k, ind])
+                    self._input_data.non_ag_w_rk[ind, k] * self.X_non_ag_vars_kr[k, ind]
                 )  # Non-agricultural contribution
                 for k in range(self._input_data.n_non_ag_lus)
             )

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -856,7 +856,7 @@ def write_water(data: Data, yr_cal, path):
                                 , 'PROPORTION_ALL_%'] )
 
     # Get water use limits used as constraints in model
-    w_net_yield_limits = ag_water.get_water_net_yield_limits(data, yr_cal)
+    w_net_yield_limits = ag_water.get_water_net_yield_limit_values(data, yr_cal)
 
     # Set up data for river regions or drainage divisions
     if settings.WATER_REGION_DEF == 'Drainage Division':


### PR DESCRIPTION
Adds the 'RELAXED_WATER_LIMITS_FOR_INFEASIBILITY ' setting which, if enabled, relaxes water constraints slightly to avoid infeasibility errors when non-agricultural land uses are irreversible.