### PR TITLE
No-Go Land Uses and Adjustable Simulation Base Year

### DIFF
--- a/luto/data.py
+++ b/luto/data.py
@@ -132,6 +132,7 @@ class Data:
         """
         # Path for write module - overwrite when provided with a base and target year
         self.path = None
+        self.path_begin_end_compare = None
         # Timestamp of simulation to which this object belongs - will be updated each time a simulation
         # is run using this Data object.
         self.timestamp_sim = timestamp
@@ -150,8 +151,6 @@ class Data:
         print('Beginning data initialisation...')
 
         self.YR_CAL_BASE = 2010  # The base year, i.e. where year index yr_idx == 0.
-
-
 
         ###############################################################
         # Masking and spatial coarse graining.
@@ -652,7 +651,7 @@ class Data:
         self.AG_MAN_L_MRJ_DICT = get_base_am_vars(self.NCELLS, self.NLMS, self.N_AG_LUS)
         self.add_ag_man_dvars(self.YR_CAL_BASE, self.AG_MAN_L_MRJ_DICT)
         
-        print("\tCalculating base year productivity...", flush=True)
+        print(f"\tCalculating year productivity...", flush=True)
         yr_cal_base_prod_data = self.get_production(self.YR_CAL_BASE, self.LUMAP, self.LMMAP)
         self.add_production_data(self.YR_CAL_BASE, "Production", yr_cal_base_prod_data)
 
@@ -1372,8 +1371,7 @@ class Data:
         self.FENCE_COST_MULTS = pd.read_excel(cost_mult_excel, "Fencing cost multiplier", index_col="Year")["Fencing_cost_multiplier"].to_dict()
 
 
-        print("Data loading complete\n")
-        
+        print("Data loading complete\n")        
 
     def get_coord(self, index_ij: np.ndarray, trans):
         """
@@ -1793,14 +1791,14 @@ class Data:
         """
         self.obj_vals[yr] = obj_val
 
-    def set_path(self, base_year, target_year) -> str:
+    def set_path(self, base_year, target_year, step_size, years) -> str:
         """Create a folder for storing outputs and return folder name."""
 
         # Get the years to write
         if settings.MODE == "snapshot":
             yr_all = [base_year, target_year]
         elif settings.MODE == "timeseries":
-            yr_all = list(range(base_year, target_year + 1))
+            yr_all = list(range(base_year, target_year + 1, step_size))
 
         # Create path name
         self.path = f"{OUTPUT_DIR}/{self.timestamp_sim}_RF{settings.RESFACTOR}_{yr_all[0]}-{yr_all[-1]}_{settings.MODE}"
@@ -1814,14 +1812,14 @@ class Data:
 
         # Add the path for the comparison between base-year and target-year if in the timeseries mode
         if settings.MODE == "timeseries":
-            path_begin_end_compare = f"{self.path}/begin_end_compare_{yr_all[0]}_{yr_all[-1]}"
+            self.path_begin_end_compare = f"{self.path}/begin_end_compare_{yr_all[0]}_{yr_all[-1]}"
             paths = (
                 paths
-                + [path_begin_end_compare]
+                + [self.path_begin_end_compare]
                 + [
-                    f"{path_begin_end_compare}/out_{yr_all[0]}",
-                    f"{path_begin_end_compare}/out_{yr_all[-1]}",
-                    f"{path_begin_end_compare}/out_{yr_all[-1]}/lucc_separate",
+                    f"{self.path_begin_end_compare}/out_{yr_all[0]}",
+                    f"{self.path_begin_end_compare}/out_{yr_all[-1]}",
+                    f"{self.path_begin_end_compare}/out_{yr_all[-1]}/lucc_separate",
                 ]
             )
 

--- a/luto/economics/agricultural/transitions.py
+++ b/luto/economics/agricultural/transitions.py
@@ -69,6 +69,14 @@ def get_exclude_matrices(data: Data, lumap: np.ndarray):
     t_ij = data.AG_TMATRIX
 
     lumap_2010 = data.LUMAP
+    
+    if settings.EXCLUDE_NO_GO_LU:
+        no_go_regions = data.NO_GO_REGION_AG
+        no_go_j = [data.DESC2AGLU.get(desc) for desc in data.NO_GO_LANDUSE_AG]
+
+        for count, j in enumerate(no_go_j):
+            x_mrj[0, :, j] *= no_go_regions[count]
+            x_mrj[1, :, j] *= no_go_regions[count]
 
     # Get all agricultural and non-agricultural cells
     ag_cells, non_ag_cells = tools.get_ag_and_non_ag_cells(lumap)

--- a/luto/economics/non_agricultural/transitions.py
+++ b/luto/economics/non_agricultural/transitions.py
@@ -1217,6 +1217,12 @@ def get_exclude_matrices(data: Data, ag_x_mrj, lumap) -> np.ndarray:
     if NON_AG_LAND_USES['BECCS']:
         non_ag_x_matrices['BECCS'] = get_exclusions_beccs(data, lumap)
 
+    if settings.EXCLUDE_NO_GO_LU:
+        no_go_regions = data.NO_GO_REGION_NON_AG
+        for count, desc in enumerate(data.NO_GO_LANDUSE_NON_AG):
+            if desc in non_ag_x_matrices.keys():
+                non_ag_x_matrices[desc] *= no_go_regions[count]
+
     # reshape each non-agricultural matrix to be indexed (r, k) and concatenate on the k indexing
     non_ag_x_matrices = [array.reshape((data.NCELLS, 1)) for array in non_ag_x_matrices.values()]
     return np.concatenate(non_ag_x_matrices, axis=1).astype(np.float32)

--- a/luto/settings.py
+++ b/luto/settings.py
@@ -160,6 +160,7 @@ THREADS = 32
 # No-Go areas; Regional adoption constraints
 # ---------------------------------------------------------------------------- #
 
+EXCLUDE_NO_GO_LU = True
 NO_GO_VECTORS = {
     'Winter cereals':           f'{os.path.abspath(INPUT_DIR)}/no_go_areas/no_go_Winter_cereals.shp',
     'Environmental Plantings':  f'{os.path.abspath(INPUT_DIR)}/no_go_areas/no_go_Enviornmental_Plantings.shp'

--- a/luto/simulation.py
+++ b/luto/simulation.py
@@ -45,6 +45,12 @@ from luto.tools.create_task_runs.helpers import log_memory_usage
 from luto.tools.report.data_tools import get_all_files
 from luto.tools.write import write_outputs
 
+from luto.tools import calc_major_vegetation_group_ag_area_for_year, calc_species_ag_area_for_year
+from luto.economics.agricultural.biodiversity import get_major_vegetation_matrices
+import luto.economics.agricultural.ghg as ag_ghg
+import luto.economics.agricultural.biodiversity as ag_biodiversity
+
+
 # Get date and time
 timestamp = datetime.now().strftime('%Y_%m_%d__%H_%M_%S')
 
@@ -59,32 +65,64 @@ def load_data() -> Data:
     
     return Data(timestamp=timestamp)
 
+
 @tools.LogToFile(f"{settings.OUTPUT_DIR}/run_{timestamp}", 'a')
-def run( data: Data, base: int, target: int) -> None:
+def run(
+    data: Data, 
+    base_year: int | None = None, 
+    target_year: int | None = None, 
+    *,
+    step_size: int | None = None,
+    years: list[int] | None = None,
+) -> None:
     """
     Run the simulation.
+
     Parameters:
-        'data' is a Data object, and 'base' and 'target' are the base and target years for the whole simulation.
+        - data: is a Data object which is previously loaded using load_data(),
+        - base_year: optional argument base year for the simulation,
+        - target_year: optional target year for the simulation,
+        - step size: optional argument to specify the increments in which solves are run in the simulation,
+        - years: optional argument to specify the years for which the simulation is run.
+
+    Some Functionality Notes:
+        - If neither 'step size' nor 'years' are provided, the simulation is run sequentially from base to target year.
+        - 'Years' essentially replaces base_year, target_year and step_size to allow for more flexibility so these
+          should not be provided alongside 'years'.
     """
+    validate_simulation_years_settings(data.YR_CAL_BASE, base_year, target_year, step_size, years)
+
+    if not step_size:
+        step_size = 1
+
+    if base_year != data.YR_CAL_BASE:
+        populate_containers_dynamic_base_year(data, base_year)
+
     memory_thread = threading.Thread(target=log_memory_usage, daemon=True)
     memory_thread.start()
     
     # Set Data object's path and create output directories
-    data.set_path(base, target)
+    data.set_path(base_year, target_year, step_size, years)
 
     # Run the simulation up to `year` sequentially.
     if settings.MODE == 'timeseries':
         if len(data.D_CY.shape) != 2:
             raise ValueError( "Demands need to be a time series array of shape (years, commodities) and years > 0." )
-        if target - base > data.D_CY.shape[0]:
+        if target_year - base_year > data.D_CY.shape[0]:
             raise ValueError( "Not enough years in demands time series.")
 
-        steps = target - base
-        solve_timeseries(data, steps, base, target)
+        if years:
+            years_to_run = years
+        else:
+            years_to_run = list(range(base_year, target_year + 1, step_size))
+            if target_year not in years_to_run:
+                years_to_run.append(target_year)
+
+        solve_timeseries(data, years_to_run)
 
     elif settings.MODE == 'snapshot':
         # If demands is a time series, choose the appropriate entry.
-        solve_snapshot(data, base, target)
+        solve_snapshot(data, base_year, target_year)
 
     else:
         raise ValueError(f"Unkown MODE: {settings.MODE}.")
@@ -93,24 +131,122 @@ def run( data: Data, base: int, target: int) -> None:
     write_outputs(data)
 
 
-def solve_timeseries(data: Data, steps: int, base: int, target: int):
-    print('\n')
-    print(f"Running LUTO {settings.VERSION} timeseries from {base} to {target} at resfactor {settings.RESFACTOR}.", flush=True)
+def validate_simulation_years_settings(
+    data_yr_cal_base: int,
+    base_year: int | None = None, 
+    target_year: int | None = None, 
+    step_size: int | None = None,
+    years: list[int] | None = None,
+) -> None:
+    """
+    Validates the years settings given to run a simulation.
+    Raises errors or warnings if the settings don't adhere to the following rules:
+    - if 'years' list is provided, it must have at least two years in it (the first year is the solve's base year)
+    - if 'years' list is provided, all other years settings should not be specified 
+    - if 'years' list is provided, it must be in ascending order
+    - the 'years' list cannot be specified for snapshot solves
+    - 'step_size' argument will be ignored for snapshot solves
+    - 'base_year' must be greater than 2010 and less than 'target_year'
+    """
+    if years:
+        if len(years) < 2:
+            raise ValueError("'years' must be populated with at least two years (inclusive of a base year).")
 
-    for s in range(steps):
+        if step_size or base_year or target_year:
+            raise ValueError("'years' cannot be specified with step_size, base_year or target_year.")
+        
+        if years != sorted(years):
+            raise ValueError("'years' must be in ascending order.")
+        
+        if settings.MODE == 'snapshot':
+            raise ValueError("'years' cannot be specified for snapshot solves.")
+
+    if settings.MODE == 'snapshot' and step_size:
+        print(f"WARNING: Step size: {step_size} is ignored when settings.MODE is 'snapshot'.")
+
+    if not years:
+        if not base_year or not target_year:
+            raise ValueError("Both base and target years, or 'years' argument, must be specified.")
+
+    if base_year < data_yr_cal_base or base_year >= target_year:
+        raise ValueError(f"Base year must be >= {data_yr_cal_base} and less than the target year.")
+
+
+def populate_containers_dynamic_base_year(
+    data: Data,
+    base_year: int,
+) -> None:
+    """
+    If the base year parsed to run() is not the same as data.YR_CAL_BASE
+    then
+        - Calculate and add data for the base year for containers. If this is not possible,
+        - Copy the data from the most recent year to the base year container.
+    """
+    year_before_base_year = max([y for y in list(data.lumaps.keys()) if y < base_year])
+
+    data.lumaps[base_year] = data.lumaps[year_before_base_year]
+    data.lmmaps[base_year] = data.lmmaps[year_before_base_year]
+    data.ammaps[base_year] = data.ammaps[year_before_base_year]
+    data.ag_dvars[base_year] = data.ag_dvars[year_before_base_year]
+    data.non_ag_dvars[base_year] = data.non_ag_dvars[year_before_base_year]
+    data.ag_man_dvars[base_year] = data.ag_man_dvars[year_before_base_year]
+
+    # Populate production containers
+    if year_before_base_year == data.YR_CAL_BASE:
+        ghg_emission_data = (
+            ag_ghg.get_ghg_matrices(data, 0, aggregate=True) 
+            * data.ag_dvars[data.YR_CAL_BASE]
+        ).sum()
+        biodiversity_data = (ag_biodiversity.get_breq_matrices(data) * data.ag_dvars[data.YR_CAL_BASE]).sum()
+        major_vegetation_data = calc_major_vegetation_group_ag_area_for_year(
+            get_major_vegetation_matrices(data), 
+            data.lumaps[data.YR_CAL_BASE],
+            data.BIODIV_HABITAT_DEGRADE_LOOK_UP,
+        )
+        species_conservation_data = calc_species_ag_area_for_year(
+            ag_biodiversity.get_species_conservation_matrix(data, data.YR_CAL_BASE),
+            data.lumaps[year_before_base_year],
+            data.BIODIV_HABITAT_DEGRADE_LOOK_UP,
+        )
+        
+    else:
+        ghg_emission_data = data.prod_data[year_before_base_year]["GHG Emissions"]
+        biodiversity_data = data.prod_data[year_before_base_year]["Biodiversity"]
+        major_vegetation_data = data.prod_data[year_before_base_year]["Major Vegetation Groups"]
+        species_conservation_data = data.prod_data[year_before_base_year]["Species Conservation"]
+
+    data.add_production_data(base_year, "Production", data.prod_data[year_before_base_year]["Production"])
+    data.add_production_data(base_year, "GHG Emissions", ghg_emission_data)
+    data.add_production_data(base_year, "Biodiversity", biodiversity_data)
+    data.add_production_data(base_year, "Major Vegetation Groups", major_vegetation_data)
+    data.add_production_data(base_year, "Species Conservation", species_conservation_data)    
+
+
+def solve_timeseries(data: Data, years_to_run: list[int]) -> None:
+    print('\n')
+    print(f"Running LUTO {settings.VERSION} timeseries from {years_to_run[0]} to {years_to_run[-1]} at resfactor {settings.RESFACTOR}.", flush=True)
+
+    final_year = years_to_run[-1]
+
+    for s in range(len(years_to_run) - 1):
+        base_year = years_to_run[s]
+        target_year = years_to_run[s + 1]
+
         print( "-------------------------------------------------")
-        print( f"Running for year {base + s + 1}"   )
+        print( f"Running for year {target_year}"   )
         print( "-------------------------------------------------\n" )
         start_time = time.time()
 
-        input_data = get_input_data(data, base + s, base + s + 1)
+        input_data = get_input_data(data, base_year, target_year)
         d_c = data.D_CY[s + 1]
 
         if s == 0:
-            luto_solver = LutoSolver(input_data, d_c, target)
+            luto_solver = LutoSolver(input_data, d_c, final_year)
             luto_solver.formulate()
 
         if s > 0:
+            prev_base_year = years_to_run[s - 1]
+
             old_ag_x_mrj = luto_solver._input_data.ag_x_mrj.copy()
             old_ag_man_lb_mrj = luto_solver._input_data.ag_man_lb_mrj.copy()
             old_non_ag_x_rk = luto_solver._input_data.non_ag_x_rk.copy()
@@ -123,15 +259,15 @@ def solve_timeseries(data: Data, steps: int, base: int, target: int):
                 old_ag_man_lb_mrj=old_ag_man_lb_mrj,
                 old_non_ag_x_rk=old_non_ag_x_rk,
                 old_non_ag_lb_rk=old_non_ag_lb_rk,
-                old_lumap=data.lumaps[base + s - 1],
-                current_lumap=data.lumaps[base + s],
-                old_lmmap=data.lmmaps[base + s - 1],
-                current_lmmap=data.lmmaps[base + s],
+                old_lumap=data.lumaps[prev_base_year],
+                current_lumap=data.lumaps[base_year],
+                old_lmmap=data.lmmaps[prev_base_year],
+                current_lmmap=data.lmmaps[base_year],
             )
 
         solution = luto_solver.solve()
 
-        yr = base + s + 1
+        yr = target_year
         data.add_lumap(yr, solution.lumap)
         data.add_lmmap(yr, solution.lmmap)
         data.add_ammaps(yr, solution.ammaps)
@@ -144,39 +280,39 @@ def solve_timeseries(data: Data, steps: int, base: int, target: int):
         for data_type, prod_data in solution.prod_data.items():
             data.add_production_data(yr, data_type, prod_data)
 
-        print(f'Processing for {base + s + 1} completed in {round(time.time() - start_time)} seconds\n\n' )
+        print(f'Processing for {target_year} completed in {round(time.time() - start_time)} seconds\n\n' )
 
 
-def solve_snapshot(data: Data, base: int, target: int):
+def solve_snapshot(data: Data, base_year: int, target_year: int):
     if len(data.D_CY.shape) == 2:
-        d_c = data.D_CY[ target - data.YR_CAL_BASE ]       # Demands needs to be a timeseries from 2010 to target year
+        d_c = data.D_CY[target_year - data.YR_CAL_BASE]       # Demands needs to be a timeseries from 2010 to target year
     else:
         d_c = data.D_CY
 
     print('\n')
-    print( f"Running LUTO {settings.VERSION} snapshot for {target} at resfactor {settings.RESFACTOR}" )
-    print( "-------------------------------------------------" )
-    print( f"Running for year {target}" )
-    print( "-------------------------------------------------" )
+    print(f"Running LUTO {settings.VERSION} snapshot for {target_year} at resfactor {settings.RESFACTOR}")
+    print("-------------------------------------------------")
+    print(f"Running for year {target_year}")
+    print("-------------------------------------------------")
 
     start_time = time.time()
-    input_data = get_input_data(data, base, target)
-    luto_solver = LutoSolver(input_data, d_c, target)
+    input_data = get_input_data(data, base_year, target_year)
+    luto_solver = LutoSolver(input_data, d_c, target_year)
     luto_solver.formulate()
 
     solution = luto_solver.solve()
-    data.add_lumap(target, solution.lumap)
-    data.add_lmmap(target, solution.lmmap)
-    data.add_ammaps(target, solution.ammaps)
-    data.add_ag_dvars(target, solution.ag_X_mrj)
-    data.add_non_ag_dvars(target, solution.non_ag_X_rk)
-    data.add_ag_man_dvars(target, solution.ag_man_X_mrj)
-    data.add_obj_vals(target, solution.obj_val)
+    data.add_lumap(target_year, solution.lumap)
+    data.add_lmmap(target_year, solution.lmmap)
+    data.add_ammaps(target_year, solution.ammaps)
+    data.add_ag_dvars(target_year, solution.ag_X_mrj)
+    data.add_non_ag_dvars(target_year, solution.non_ag_X_rk)
+    data.add_ag_man_dvars(target_year, solution.ag_man_X_mrj)
+    data.add_obj_vals(target_year, solution.obj_val)
 
     for data_type, prod_data in solution.prod_data.items():
-        data.add_production_data(target, data_type, prod_data)
+        data.add_production_data(target_year, data_type, prod_data)
 
-    print(f'Processing for {target} completed in {round(time.time() - start_time)} seconds\n\n')
+    print(f'Processing for {target_year} completed in {round(time.time() - start_time)} seconds\n\n')
 
 
 def save_data_to_disk(data: Data, path: str, compress_level=9) -> None:

--- a/luto/tools/write.py
+++ b/luto/tools/write.py
@@ -113,8 +113,7 @@ def write_data(data: Data):
     
     # Write the area/quantity comparison between base-year and target-year for the timeseries mode
     if complete_simulation:
-        begin_end_path = f"{data.path}/begin_end_compare_{years[0]}_{years[-1]}"
-        jobs += [delayed(write_output_single_year)(data, years[-1], f"{begin_end_path}/out_{years[-1]}", years[0])] if settings.MODE == 'timeseries' else []
+        jobs += [delayed(write_output_single_year)(data, years[-1], f"{data.path_begin_end_compare}/out_{years[-1]}", years[0])] if settings.MODE == 'timeseries' else []
     else:
         print(f'''The target year is not the last year in the simulation!
                   Only Writing the avaliable outputs ({years[0]}-{years[-1]}) to output directory.\n''')
@@ -125,7 +124,7 @@ def write_data(data: Data):
 
     # Copy the base-year outputs to the path_begin_end_compare
     if complete_simulation:
-        shutil.copytree(f"{data.path}/out_{years[0]}", f"{begin_end_path}/out_{years[0]}", dirs_exist_ok = True) if settings.MODE == 'timeseries' else None
+        shutil.copytree(f"{data.path}/out_{years[0]}", f"{data.path_begin_end_compare}/out_{years[0]}", dirs_exist_ok = True) if settings.MODE == 'timeseries' else None
     
     # Create the report HTML and png maps
     TIF2MAP(data.path) if settings.WRITE_OUTPUT_GEOTIFFS else None
@@ -1024,7 +1023,6 @@ def write_biodiversity_GBF3_scores(data: Data, yr_cal: int, path) -> None:
     if not settings.BIODIVERSTIY_TARGET_GBF_3 == 'on':
         return
     
-    yr_idx = yr_cal - data.YR_CAL_BASE
     veg_base_score_score = pd.DataFrame({
         'vg': data.BIO_GBF3_ID2DESC.values(), 
         'BASE_OUTSIDE_SCORE': data.BIO_GBF3_BASELINE_SCORE_OUTSIDE_LUTO, 


### PR DESCRIPTION
PR containing the implementation of no-go land uses and the changes for adjustable simulation base year.

The PR also includes the option to specify a 'step size' for timeseries solves (skipping years at a given step size), and the option to specify specifically which years to run a timeseries solve for. These are the `step_size` and `years` key word arguments to the `sim.run` function.

Examples:
`sim.run(data, 2012, 2020, step_size=2)` - runs for the years 2014, 2016, 2018 and 2020 with the base year being 2012.
`sim.run(data, years=[2010, 2020, 2025, 2030, 2050])` - runs for the years specified in the `years` KW argument list.