### PR TITLE
feat: add hard demand constraint with per-commodity upper bounds

### DIFF
--- a/luto/settings.py
+++ b/luto/settings.py
@@ -162,6 +162,20 @@ SOLVER_WEIGHT_DEMAND = 1
 SOLVER_WEIGHT_GHG = 1
 SOLVER_WEIGHT_WATER = 1
 
+DEMAND_CONSTRAINT_TYPE = 'soft'   # 'soft': penalise under-production in objective (current behaviour)
+# DEMAND_CONSTRAINT_TYPE = 'hard'  # 'hard': enforce production >= demand (lower bound = 1.0x) and
+#                                  #         production <= DEMAND_UPPER_BOUND (upper bound per commodity)
+
+# Upper bound multipliers applied only when DEMAND_CONSTRAINT_TYPE == 'hard'.
+# Keys must match entries in data.COMMODITIES (lowercase). '__default__' applies to all others.
+DEMAND_UPPER_BOUND = {
+    'sheep meat':         1.15,
+    'sheep lexp':         1.10,
+    'sheep wool':         1.05,
+    'beef lexp':          1.05,
+    '__default__':        1.01,
+}
+
 RESCALE_FACTOR = 1e3
 '''
 All input data before feeding into the solver is rescaled in the range between 0 and this factor.

--- a/luto/solvers/input_data.py
+++ b/luto/solvers/input_data.py
@@ -114,6 +114,8 @@ class SolverInputData:
     base_yr_prod: dict[str, tuple]                                      # Base year production of each commodity.
     scale_factors: dict[float]                                          # Scale factors for each input layer.
 
+    commodity_names: list[str]                                          # Commodity names ordered by commodity index (matches pr2cm_cp rows).
+
     economic_contr_mrj: float                                           # base year economic contribution matrix.
     economic_prices: np.ndarray                                         # base year commodity prices.
     economic_target_yr_carbon_price: float                              # target year carbon price.
@@ -1214,7 +1216,8 @@ def get_input_data(data: Data, base_year: int, target_year: int) -> SolverInputD
 
         base_yr_prod,
         scale_factors,
-        
+        data.COMMODITIES,
+
         economic_contr_mrj,
         economic_prices,
         economic_target_yr_carbon_price,

--- a/luto/solvers/solver.py
+++ b/luto/solvers/solver.py
@@ -348,8 +348,9 @@ class LutoSolver:
         4) [B] A single penalty scalar for biodiversity, minimises its deviation from the target.
         """
         print("│   └── Setting up decision variables for soft constraints...")
-        
-        self.V = self.gurobi_model.addMVar(self._input_data.ncms, lb=0, name="V") # force lb=0 to make sure demand penalties are positive; i.e., demand must be met or exceeded
+
+        if settings.DEMAND_CONSTRAINT_TYPE == 'soft':
+            self.V = self.gurobi_model.addMVar(self._input_data.ncms, lb=0, name="V")  # lb=0: demand must be met or exceeded
 
         if settings.GHG_CONSTRAINT_TYPE == "soft":
             self.E = self.gurobi_model.addVar(name="E")
@@ -460,14 +461,17 @@ class LutoSolver:
         weight_water = 0
 
         # Get the penalty values for each sector
-        penalty_demand = (
-            gp.quicksum(
-                self.V[c] * self._input_data.scale_factors['Demand'] * price
-                for c, price in enumerate(self._input_data.economic_prices)
-            ) 
-            * settings.SOLVER_WEIGHT_DEMAND
-            / 1e6  # Convert to million AUD
-        )
+        if settings.DEMAND_CONSTRAINT_TYPE == 'soft':
+            penalty_demand = (
+                gp.quicksum(
+                    self.V[c] * self._input_data.scale_factors['Demand'] * price
+                    for c, price in enumerate(self._input_data.economic_prices)
+                )
+                * settings.SOLVER_WEIGHT_DEMAND
+                / 1e6  # Convert to million AUD
+            )
+        else:
+            penalty_demand = gp.LinExpr(0)
     
         if settings.GHG_CONSTRAINT_TYPE == "soft":
             weight_ghg = settings.SOLVER_WEIGHT_GHG
@@ -673,15 +677,37 @@ class LutoSolver:
         ]
 
         demand_scale = self._input_data.scale_factors['Demand']
-        lower_bound_constraints = self.gurobi_model.addConstrs(
-            (
-                (self.total_q_exprs_c[c] - self._input_data.limits['demand'][c] / demand_scale) == self.V[c]
-                for c in range(self._input_data.ncms)
-            ),  name="demand_soft_bound_lower"
-        )
 
-        # self.demand_penalty_constraints.extend(upper_bound_constraints.values())
-        self.demand_penalty_constraints.extend(lower_bound_constraints.values())
+        if settings.DEMAND_CONSTRAINT_TYPE == 'soft':
+            lower_bound_constraints = self.gurobi_model.addConstrs(
+                (
+                    (self.total_q_exprs_c[c] - self._input_data.limits['demand'][c] / demand_scale) == self.V[c]
+                    for c in range(self._input_data.ncms)
+                ),  name="demand_soft_bound_lower"
+            )
+            self.demand_penalty_constraints.extend(lower_bound_constraints.values())
+        else:
+            print("│   ├── Adding <hard> demand constraints (lower + upper bounds, no penalty)...")
+            lower_bound_constraints = self.gurobi_model.addConstrs(
+                (
+                    self.total_q_exprs_c[c] >= self._input_data.limits['demand'][c] / demand_scale
+                    for c in range(self._input_data.ncms)
+                ),  name="demand_hard_bound_lower"
+            )
+            upper_bound_constraints = self.gurobi_model.addConstrs(
+                (
+                    self.total_q_exprs_c[c] <= (
+                        self._input_data.limits['demand'][c] / demand_scale
+                        * settings.DEMAND_UPPER_BOUND.get(
+                            self._input_data.commodity_names[c],
+                            settings.DEMAND_UPPER_BOUND['__default__']
+                        )
+                    )
+                    for c in range(self._input_data.ncms)
+                ),  name="demand_hard_bound_upper"
+            )
+            self.demand_penalty_constraints.extend(lower_bound_constraints.values())
+            self.demand_penalty_constraints.extend(upper_bound_constraints.values())
 
 
     def _get_water_net_yield_expr_for_region(


### PR DESCRIPTION
Adds DEMAND_CONSTRAINT_TYPE ('soft'/'hard') and DEMAND_UPPER_BOUND settings. In hard mode, Gurobi enforces production >= demand (lower bound) and <= demand * upper_bound (per commodity, default 1.01). Soft mode behaviour is unchanged.